### PR TITLE
Changing API Gateway URL to localhost. If we don't set this explicitly Swagger UI fails when trying out an API

### DIFF
--- a/docker-compose/pattern-1/api-manager/carbon/repository/conf/api-manager.xml
+++ b/docker-compose/pattern-1/api-manager/carbon/repository/conf/api-manager.xml
@@ -93,7 +93,7 @@
                 <!-- Admin password for the API gateway.-->
                 <Password>${admin.password}</Password>
                 <!-- Endpoint URLs for the APIs hosted in this API gateway.-->
-                <GatewayEndpoint>http://${carbon.local.ip}:${http.nio.port},https://${carbon.local.ip}:${https.nio.port}</GatewayEndpoint>
+                <GatewayEndpoint>http://localhost:${http.nio.port},https://localhost:${https.nio.port}</GatewayEndpoint>
             </Environment>
         </Environments>
     </APIGateway>


### PR DESCRIPTION
Swagger UI try to send the request to local IP of docker container. This fails because it's not accessible from the host.