### PR TITLE
Fix formatting issue in links within README.md files

### DIFF
--- a/dockerfiles/apim-analytics/README.md
+++ b/dockerfiles/apim-analytics/README.md
@@ -55,8 +55,8 @@ command the absolute path of the `conf` directory should be set as the `source`.
 
 ## Docker command usage references
 
-* [Docker build command reference] (https://docs.docker.com/engine/reference/commandline/build/)
+* [Docker build command reference](https://docs.docker.com/engine/reference/commandline/build/)
 
-* [Dockerfile reference] (https://docs.docker.com/engine/reference/builder/)
+* [Dockerfile reference](https://docs.docker.com/engine/reference/builder/)
 
-* [Docker run command reference] (https://docs.docker.com/engine/reference/run/)
+* [Docker run command reference](https://docs.docker.com/engine/reference/run/)

--- a/dockerfiles/apim-analytics/README.md
+++ b/dockerfiles/apim-analytics/README.md
@@ -56,7 +56,5 @@ command the absolute path of the `conf` directory should be set as the `source`.
 ## Docker command usage references
 
 * [Docker build command reference](https://docs.docker.com/engine/reference/commandline/build/)
-
-* [Dockerfile reference](https://docs.docker.com/engine/reference/builder/)
-
 * [Docker run command reference](https://docs.docker.com/engine/reference/run/)
+* [Dockerfile reference](https://docs.docker.com/engine/reference/builder/)

--- a/dockerfiles/apim/README.md
+++ b/dockerfiles/apim/README.md
@@ -58,8 +58,8 @@ command the absolute path of the `conf` directory should be set as the `source`.
 
 ## Docker command usage references
 
-* [Docker build command reference] (https://docs.docker.com/engine/reference/commandline/build/)
+* [Docker build command reference](https://docs.docker.com/engine/reference/commandline/build/)
 
-* [Dockerfile reference] (https://docs.docker.com/engine/reference/builder/)
+* [Dockerfile reference](https://docs.docker.com/engine/reference/builder/)
 
-* [Docker run command reference] (https://docs.docker.com/engine/reference/run/)
+* [Docker run command reference](https://docs.docker.com/engine/reference/run/)

--- a/dockerfiles/apim/README.md
+++ b/dockerfiles/apim/README.md
@@ -59,7 +59,5 @@ command the absolute path of the `conf` directory should be set as the `source`.
 ## Docker command usage references
 
 * [Docker build command reference](https://docs.docker.com/engine/reference/commandline/build/)
-
-* [Dockerfile reference](https://docs.docker.com/engine/reference/builder/)
-
 * [Docker run command reference](https://docs.docker.com/engine/reference/run/)
+* [Dockerfile reference](https://docs.docker.com/engine/reference/builder/)


### PR DESCRIPTION
## Purpose
> This pull request fixes a formatting issue caused by incorrect README.md file syntax used to define links.

## Goals
> Correct the README.md file syntax to define links, to fix the formatting issue.

## Approach
> Add correct README.md file syntax to define links, to fix the formatting issue.