### PR TITLE
Refine the standalone WSO2 API Manager Dockerfile README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,13 @@
 This repository contains following Docker resources:
 
 - WSO2 API Manager Dockerfile
+- WSO2 API Manager Analytics Dockerfile
 - WSO2 API Manager Docker Compose Templates
 
-The WSO2 API Manager Dockerfile builds a generic Docker image for deploying API Manager in containerized environments. It includes the JDK, product distribution and a collection of utility libraries. Configurations, JDBC driver, extensions and other deployable artifacts are designed to be provided via volume mounts.
+The WSO2 API Manager and API Manager Analytics Dockerfiles build generic Docker images <br>
+for deploying API Manager and API Manager Analytics in containerized environments. They<br>
+include the JDK, product distributions and a collection of utility libraries. Configurations, JDBC<br>
+driver, extensions and other deployable artifacts are designed to be provided via volume mounts.
 
-The Docker Compose templates have been created according to standard API Manager deployment patterns for allowing users to evaluate the product and understand the deployment architecture in depth.
+The Docker Compose templates have been created according to standard API Manager deployment patterns
+for allowing users to evaluate the product and understand the deployment architecture in depth.

--- a/dockerfiles/apim-analytics/README.md
+++ b/dockerfiles/apim-analytics/README.md
@@ -56,7 +56,7 @@ docker run
 wso2am-analytics:2.1.0
 ```
 
->In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2am-analytics-2.1.0/conf folder of the container.
+>In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2am-analytics-2.1.0/repository/conf folder of the container.
 
 
 ## Docker command usage references

--- a/dockerfiles/apim-analytics/README.md
+++ b/dockerfiles/apim-analytics/README.md
@@ -1,57 +1,63 @@
 # Dockerfile for WSO2 API Manager Analytics #
-
-The Dockerfile defines the resources and instructions to build the Docker image for WSO2 API Manager Analytics 2.1.0.
+The section defines the step-by-step instructions to build the Docker image for WSO2 API Manager Analytics 2.1.0.
 
 ## How to build an image and run
+##### 1. Checkout this repository into your local machine using the following git command.
+```
+git clone https://github.com/wso2/docker-apim.git
+```
 
- Follow below steps to build the WSO2 API Manager Analytics 2.1.0 Docker image and run in your local machine.
- 
- The local copy of the `Dockerfile` directory will be referred as, `DOCKERFILE_HOME`.
- 
- * Add the JDK and WSO2 API Manager Analytics distributions to `files` directory:
-     - Download JDK 1.8 (http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) and copy it to `<DOCKERFILE_HOME>/files`.
-     - Download the WSO2 API Manager Analytics 2.1.0 distribution (http://wso2.com/api-management/try-it/) and copy it to `<DOCKERFILE_HOME>/files`.
-     Please refer [WSO2 Update Manager documentation](https://docs.wso2.com/display/ADMIN44x/Updating+WSO2+Products) to obtained the WSO2 API Manager Analytics 2.1.0
-   with latest bug fixes and updates.
- 
- * Build the Docker image:
-     - Navigate to `<DOCKERFILE_HOME>` directory.
-     - Execute the `docker build` command as shown below;
-         + `docker build -t wso2am-analytics:2.1.0 .`
- 
- * Docker run:
-     - Run the WSO2 API Manager Analytics 2.1.0 Docker container as follows:
-         + `docker run -it -p 9444:9444 wso2am-analytics:2.1.0`
-         
-       **Note**: Here, only port 9444 (HTTPS servlet transport) has been mapped to a Docker host port.
-       You may map other container service ports, which have been exposed to Docker host ports, as desired.
- 
- * Access management console:
-     -  To access the management console, use the Docker host IP and port 9443.
-         + `https://<DOCKER_HOST>:9444/carbon`
+>The local copy of the `dockerfile` directory will be referred to as `DOCKERFILE_HOME` from this point onwards.
+
+##### 2. Add JDK and WSO2 API Manager Analytics distributions to `<DOCKERFILE_HOME>/files`
+- Download [JDK 1.8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) 
+and copy that to `<DOCKERFILE_HOME>/files`.
+- Download the WSO2 API Manager Analytics 2.1.0 distribution (http://wso2.com/api-management/try-it/)
+and copy that to `<DOCKERFILE_HOME>/files`. <br>
+>Please refer to [WSO2 Update Manager documentation](https://docs.wso2.com/display/ADMIN44x/Updating+WSO2+Products)
+in order to obtain latest bug fixes and updates for the product.
+
+##### 3. Build the Docker image.
+- Navigate to `<DOCKERFILE_HOME>` directory. <br>
+  Execute `docker build` command as shown below.
+    + `docker build -t wso2am-analytics:2.1.0 .`
+    
+##### 4. Running the Docker image.
+- `docker run -it -p 9444:9444 wso2am-analytics:2.1.0`
+>Here, only port 9444 (HTTPS servlet transport) has been mapped to a Docker host port.
+You may map other container service ports, which have been exposed to Docker host ports, as desired.
+
+##### 6. Accessing management console.
+- To access the management console, use the docker host IP and port 9444.
+    + `https:<DOCKER_HOST>:9444/carbon`
+    
+>In here, <DOCKER_HOST> refers to hostname or IP of the host machine on top of which containers are spawned.
+
 
 ## How to update configurations
+Configurations would lie on the Docker host machine and they can be volume mounted to the container. <br>
+As an example, steps required to change the port offset using `carbon.xml` is as follows.
 
-The configurations will be maintained on the Docker host machine and volume mounted to the container.
+##### 1. Stop the API Manager container if it's already running.
+In WSO2 API Manager Analytics 2.1.0 product distribution, `carbon.xml` configuration file <br>
+can be found at `<DISTRIBUTION_HOME>/conf`. Copy the file to some suitable location of the host machine, <br>
+referred to as `<SOURCE_CONFIGS>/carbon.xml` and change the offset value under ports to 1.
 
-As an example, the steps required to change the port offset in `carbon.xml` is detailed.
+##### 2. Grant read permission to `other` users for `<SOURCE_CONFIGS>/carbon.xml`
+```
+chmod o+r <SOURCE_CONFIGS>/carbon.xml
+```
 
-* Stop the API Manager Analytics container if it's already running.
+##### 3. Run the image by mounting the file to container as follows.
+```
+docker run 
+-p 9445:9445
+--volume <SOURCE_CONFIGS>/carbon.xml:<TARGET_CONFIGS>/carbon.xml
+wso2am-analytics:2.1.0
+```
 
-* Create the required config changes in the host machine
-    - Extract the `wso2am-analytics-2.1.0.zip` file located in `DOCKERFILE_HOME/files`.
-        + Navigate to `<DOCKERFILE_HOME>/files` directory
-        + `unzip -q wso2am-analytics-2.1.0.zip`
-    - Change the port offset in `carbon.xml` file located in `DOCKERFILE_HOME/files/wso2am-analytics-2.1.0/repository/conf/` directory.
-    - Grant write permission to the `DOCKERFILE_HOME/files/wso2am-analytics-2.1.0/repository/conf/` directory on the host machine to `other` users.
-        + `sudo chmod o+w -R DOCKERFILE_HOME/files/wso2am-analytics-2.1.0/repository/conf`
+>In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2am-analytics-2.1.0/conf folder of the container.
 
-* Run the Docker container by mounting the config directory (`DOCKERFILE_HOME/files/wso2am-analytics-2.1.0/repository/conf/`) of the host machine.
-    - Navigate to `<DOCKERFILE_HOME>` directory.
-    - `docker run -it --mount type=bind,source=${PWD}/files/wso2am-analytics-2.1.0/repository/conf,target=/home/wso2carbon/wso2am-analytics-2.1.0/repository/conf wso2am-analytics:2.1.0`
-
-* If the `conf` directory on the host machine is located on a different directory than shown above, when executing the `docker run`
-command the absolute path of the `conf` directory should be set as the `source`.
 
 ## Docker command usage references
 

--- a/dockerfiles/apim/README.md
+++ b/dockerfiles/apim/README.md
@@ -1,60 +1,61 @@
 # Dockerfile for WSO2 API Manager #
-
-The Dockerfile defines the resources and instructions to build the Docker image for WSO2 API Manager 2.1.0.
+The section defines the step-by-step instructions to build the Docker image for WSO2 API Manager 2.1.0.
 
 ## How to build an image and run
+##### 1. Checkout this repository into your local machine using the following git command.
+```
+git clone https://github.com/wso2/docker-apim.git
+```
 
- Follow below steps to build the WSO2 API Manager 2.1.0 Docker image and run in your local machine.
- 
- The local copy of the `Dockerfile` directory will be referred as, `DOCKERFILE_HOME`.
- 
- * Add the JDK and WSO2 API Manager distributions to `files` directory:
-     - Download JDK 1.8 (http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) and copy it to `<DOCKERFILE_HOME>/files`.
-     - Download the WSO2 API Manager 2.1.0 distribution (http://wso2.com/api-management/try-it/) and copy it to `<DOCKERFILE_HOME>/files`.
-     Please refer [WSO2 Update Manager documentation](https://docs.wso2.com/display/ADMIN44x/Updating+WSO2+Products) to obtained the WSO2 API Manager 2.1.0
-   with latest bug fixes and updates.
- 
- * Build the Docker image:
-     - Navigate to `<DOCKERFILE_HOME>` directory.
-     - Execute the `docker build` command as shown below;
-         + `docker build -t wso2am:2.1.0 .`
- 
- * Docker run:
-     - Run the WSO2 API Manager 2.1.0 Docker container as follows:
-         + `docker run -it -p 9443:9443 wso2am:2.1.0`
-         
-       **Note**: Here, only port 9443 (HTTPS servlet transport) has been mapped to a Docker host port.
-       You may map other container service ports, which have been exposed to Docker host ports, as desired.
- 
- * Access management console:
-     -  To access the management console, use the Docker host IP and port 9443.
-         + `https://<DOCKER_HOST>:9443/carbon`
-     -  To access the store and publisher, use the Docker host IP, port 9443 and store/publisher contexts.
-         + `https://<DOCKER_HOST>:9443/store`
-         + `https://<DOCKER_HOST>:9443/publisher`
+>The local copy of the `dockerfile` directory will be referred to as `DOCKERFILE_HOME` from this point onwards.
+
+##### 2. Add JDK and WSO2 API Manager distributions to `<DOCKERFILE_HOME>/files`
+- Download [JDK 1.8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) 
+and copy that to `<DOCKERFILE_HOME>/files`.
+- Download the WSO2 API Manager 2.1.0 distribution (http://wso2.com/api-management/try-it/)
+and copy that to `<DOCKERFILE_HOME>/files`. <br>
+>Please refer to [WSO2 Update Manager documentation](https://docs.wso2.com/display/ADMIN44x/Updating+WSO2+Products)
+in order to obtain latest bug fixes and updates for the product.
+
+##### 3. Build the Docker image.
+- Navigate to `<DOCKERFILE_HOME>` directory. <br>
+  Execute `docker build` command as shown below.
+    + `docker build -t wso2am:2.1.0 .`
+    
+##### 4. Running the Docker image.
+- `docker run -it -p 9443:9443 wso2am:2.1.0`
+
+##### 6. Accessing management console.
+- To access the management console, use the docker host IP and port 9443.
+    + `https:<DOCKER_HOST>:9443/carbon`
+    
+>In here, <DOCKER_HOST> refers to hostname or IP of the host machine on top of which containers are spawned.
+
 
 ## How to update configurations
+Configurations would lie on the Docker host machine and they can be volume mounted to the container. <br>
+As an example, steps required to change the port offset using `carbon.xml` is as follows.
 
-The configurations will be maintained on the Docker Host machine and volume mounted to the container.
+##### 1. Stop the API Manager container if it's already running.
+In WSO2 API Manager 2.1.0 product distribution, `carbon.xml` configuration file <br>
+can be found at `<DISTRIBUTION_HOME>/conf`. Copy the file to some suitable location of the host machine, <br>
+referred to as `<SOURCE_CONFIGS>/carbon.xml` and change the offset value under ports to 1.
 
-As an example, the steps required to change the port offset in `carbon.xml` is detailed.
+##### 2. Grant read permission to `other` users for `<SOURCE_CONFIGS>/carbon.xml`
+```
+chmod o+r <SOURCE_CONFIGS>/carbon.xml
+```
 
-* Stop the API Manager container if it's already running.
+##### 3. Run the image by mounting the file to container as follows.
+```
+docker run 
+-p 9444:9444
+--volume <SOURCE_CONFIGS>/carbon.xml:<TARGET_CONFIGS>/carbon.xml
+wso2am:2.1.0
+```
 
-* Create the required config changes in the host machine
-    - Extract the `wso2am-2.1.0.zip` file located in `DOCKERFILE_HOME/files`.
-        + Navigate to `<DOCKERFILE_HOME>/files` directory
-        + `unzip -q wso2am-2.1.0.zip`
-    - Change the port offset in `carbon.xml` file located in `DOCKERFILE_HOME/files/wso2am-2.1.0/repository/conf/` directory.
-    - Grant write permission to the `DOCKERFILE_HOME/files/wso2am-2.1.0/repository/conf/` directory on the host machine to `other` users.
-        + `sudo chmod o+w -R DOCKERFILE_HOME/files/wso2am-2.1.0/repository/conf`
+>In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2am-2.1.0/conf folder of the container.
 
-* Run the Docker container by mounting the config directory (`DOCKERFILE_HOME/files/wso2am-2.1.0/repository/conf/`) of the host machine.
-    - Navigate to `<DOCKERFILE_HOME>` directory.
-    - `docker run -it --mount type=bind,source=${PWD}/files/wso2am-2.1.0/repository/conf,target=/home/wso2carbon/wso2am-2.1.0/repository/conf wso2am:2.1.0`
-
-* If the `conf` directory on the host machine is located on a different directory than shown above, when executing the `docker run`
-command the absolute path of the `conf` directory should be set as the `source`.
 
 ## Docker command usage references
 

--- a/dockerfiles/apim/README.md
+++ b/dockerfiles/apim/README.md
@@ -38,7 +38,7 @@ As an example, steps required to change the port offset using `carbon.xml` is as
 
 ##### 1. Stop the API Manager container if it's already running.
 In WSO2 API Manager 2.1.0 product distribution, `carbon.xml` configuration file <br>
-can be found at `<DISTRIBUTION_HOME>/conf`. Copy the file to some suitable location of the host machine, <br>
+can be found at `<DISTRIBUTION_HOME>/repository/conf`. Copy the file to some suitable location of the host machine, <br>
 referred to as `<SOURCE_CONFIGS>/carbon.xml` and change the offset value under ports to 1.
 
 ##### 2. Grant read permission to `other` users for `<SOURCE_CONFIGS>/carbon.xml`
@@ -54,7 +54,7 @@ docker run
 wso2am:2.1.0
 ```
 
->In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2am-2.1.0/conf folder of the container.
+>In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2am-2.1.0/repository/conf folder of the container.
 
 
 ## Docker command usage references


### PR DESCRIPTION
## Purpose
> Need to refine the standalone WSO2 API Manager Dockerfile README.md file. Related issue is https://github.com/wso2/docker-apim/issues/61.

## Goals
> Refine the standalone WSO2 API Manager Dockerfile README.md file.