### PR TITLE
Fix user home dir and update mysql jdbc driver

### DIFF
--- a/docker-compose/apim-analytics/README.md
+++ b/docker-compose/apim-analytics/README.md
@@ -1,4 +1,4 @@
-### WSO2 API Manager 2.1.0 Deployment Pattern 1
+### WSO2 API Manager deployment with WSO2 API Manager Analytics
 
 ![alt tag](am-2.1.0-pattern-1.png)
 
@@ -19,15 +19,15 @@
      docker pull mysql:5.7.19
      ```
 
-3. Switch to the docker-compose/pattern-1 folder:
+3. Switch to the docker-compose/apim-analytics folder:
     ```
-    cd [docker-apim]/docker-compose/pattern-1
+    cd [docker-apim]/docker-compose/apim-analytics
     ```
 
-4. Download [MySQL Connector/J](https://downloads.mysql.com/archives/c-j/) v5.1.35 and copy its JAR file to the following path:
+4. Download [MySQL Connector/J](https://dev.mysql.com/downloads/connector/j/) v5.1.45 and copy its JAR file to the following path:
     ```
-    [docker-apim]/docker-compose/pattern-1/api-manager/carbon/repository/components/lib/mysql-connector-java-5.1.35-bin.jar
-    [docker-apim]/docker-compose/pattern-1/am-analytics/carbon/repository/components/lib/mysql-connector-java-5.1.35-bin.jar
+    [docker-apim]/docker-compose/apim-analytics/api-manager/carbon/repository/components/lib/mysql-connector-java-5.1.45-bin.jar
+    [docker-apim]/docker-compose/apim-analytics/am-analytics/carbon/repository/components/lib/mysql-connector-java-5.1.45-bin.jar
     ```
 
 6. Execute the following Docker Compose command to start the deployment:

--- a/docker-compose/apim-analytics/am-analytics/carbon/repository/conf/datasources/analytics-datasources.xml
+++ b/docker-compose/apim-analytics/am-analytics/carbon/repository/conf/datasources/analytics-datasources.xml
@@ -13,7 +13,7 @@
             <description>The datasource used for analytics record store</description>
             <definition type="RDBMS">
                 <configuration>
-                    <url>jdbc:mysql://mysql:3306/stats_db?autoReconnect=true&amp;relaxAutoCommit=true</url>
+                    <url>jdbc:mysql://mysql:3306/stats_db?autoReconnect=true&amp;relaxAutoCommit=true&amp;useSSL=false</url>
                     <username>root</username>
                     <password>root</password>
                     <driverClassName>com.mysql.jdbc.Driver</driverClassName>
@@ -33,7 +33,7 @@
             <description>The datasource used for analytics record store</description>
             <definition type="RDBMS">
                 <configuration>
-                    <url>jdbc:mysql://mysql:3306/stats_db?autoReconnect=true&amp;relaxAutoCommit=true</url>
+                    <url>jdbc:mysql://mysql:3306/stats_db?autoReconnect=true&amp;relaxAutoCommit=true&amp;useSSL=false</url>
                     <username>root</username>
                     <password>root</password>
                     <driverClassName>com.mysql.jdbc.Driver</driverClassName>

--- a/docker-compose/apim-analytics/am-analytics/carbon/repository/conf/datasources/stats-datasources.xml
+++ b/docker-compose/apim-analytics/am-analytics/carbon/repository/conf/datasources/stats-datasources.xml
@@ -13,7 +13,7 @@
 	    </jndiConfig>
 	  <definition type="RDBMS">
 		  <configuration>
-			  <url>jdbc:mysql://mysql:3306/stats_db?autoReconnect=true&amp;relaxAutoCommit=true</url>
+			  <url>jdbc:mysql://mysql:3306/stats_db?autoReconnect=true&amp;relaxAutoCommit=true&amp;useSSL=false</url>
 			  <username>root</username>
 			  <password>root</password>
 			  <driverClassName>com.mysql.jdbc.Driver</driverClassName>

--- a/docker-compose/apim-analytics/api-manager/carbon/repository/conf/datasources/master-datasources.xml
+++ b/docker-compose/apim-analytics/api-manager/carbon/repository/conf/datasources/master-datasources.xml
@@ -14,7 +14,7 @@
             </jndiConfig>
             <definition type="RDBMS">
                 <configuration>
-                    <url>jdbc:mysql://mysql:3306/carbon_db?autoReconnect=true</url>
+                    <url>jdbc:mysql://mysql:3306/carbon_db?autoReconnect=true&amp;useSSL=false</url>
                     <username>root</username>
                     <password>root</password>
                     <driverClassName>com.mysql.jdbc.Driver</driverClassName>
@@ -35,7 +35,7 @@
             </jndiConfig>
             <definition type="RDBMS">
                 <configuration>
-                    <url>jdbc:mysql://mysql:3306/apimgt_db?autoReconnect=true</url>
+                    <url>jdbc:mysql://mysql:3306/apimgt_db?autoReconnect=true&amp;useSSL=false</url>
                     <username>root</username>
                     <password>root</password>
                     <defaultAutoCommit>false</defaultAutoCommit>
@@ -57,7 +57,7 @@
             </jndiConfig>
             <definition type="RDBMS">
                 <configuration>
-                    <url>jdbc:mysql://mysql:3306/stats_db?autoReconnect=true&amp;relaxAutoCommit=true</url>
+                    <url>jdbc:mysql://mysql:3306/stats_db?autoReconnect=true&amp;relaxAutoCommit=true&amp;useSSL=false</url>
                     <username>root</username>
                     <password>root</password>
                     <driverClassName>com.mysql.jdbc.Driver</driverClassName>

--- a/docker-compose/apim-analytics/docker-compose.yml
+++ b/docker-compose/apim-analytics/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       MYSQL_ROOT_PASSWORD: root
     volumes:
       - ./mysql/scripts:/docker-entrypoint-initdb.d
+    command: [--ssl=0]
     healthcheck:
       test: ["CMD", "mysqladmin" ,"ping", "-uroot", "-proot"]
       interval: 10s
@@ -27,9 +28,9 @@ services:
       mysql:
         condition: service_healthy
     volumes:
-      - ./am-analytics/carbon/repository/components/lib/mysql-connector-java-5.1.35-bin.jar:/home/wso2user/wso2am-analytics-2.1.0/repository/components/lib/mysql-connector-java-5.1.35-bin.jar
-      - ./am-analytics/carbon/repository/conf/datasources/analytics-datasources.xml:/home/wso2user/wso2am-analytics-2.1.0/repository/conf/datasources/analytics-datasources.xml
-      - ./am-analytics/carbon/repository/conf/datasources/stats-datasources.xml:/home/wso2user/wso2am-analytics-2.1.0/repository/conf/datasources/stats-datasources.xml
+      - ./am-analytics/carbon/repository/components/lib/mysql-connector-java-5.1.45-bin.jar:/home/wso2carbon/wso2am-analytics-2.1.0/repository/components/lib/mysql-connector-java-5.1.45-bin.jar
+      - ./am-analytics/carbon/repository/conf/datasources/analytics-datasources.xml:/home/wso2carbon/wso2am-analytics-2.1.0/repository/conf/datasources/analytics-datasources.xml
+      - ./am-analytics/carbon/repository/conf/datasources/stats-datasources.xml:/home/wso2carbon/wso2am-analytics-2.1.0/repository/conf/datasources/stats-datasources.xml
     links:
       - mysql
   api-manager:
@@ -43,11 +44,11 @@ services:
       am-analytics:
         condition: service_healthy
     volumes:
-      - ./api-manager/carbon/repository/components/lib/mysql-connector-java-5.1.35-bin.jar:/home/wso2user/wso2am-2.1.0/repository/components/lib/mysql-connector-java-5.1.35-bin.jar
-      - ./api-manager/carbon/repository/conf/datasources/master-datasources.xml:/home/wso2user/wso2am-2.1.0/repository/conf/datasources/master-datasources.xml
-      - ./api-manager/carbon/repository/conf/api-manager.xml:/home/wso2user/wso2am-2.1.0/repository/conf/api-manager.xml
-      - ./api-manager/carbon/repository/conf/carbon.xml:/home/wso2user/wso2am-2.1.0/repository/conf/carbon.xml
-      - ./api-manager/carbon/repository/conf/tomcat/catalina-server.xml:/home/wso2user/wso2am-2.1.0/repository/conf/tomcat/catalina-server.xml
+      - ./api-manager/carbon/repository/components/lib/mysql-connector-java-5.1.45-bin.jar:/home/wso2carbon/wso2am-2.1.0/repository/components/lib/mysql-connector-java-5.1.45-bin.jar
+      - ./api-manager/carbon/repository/conf/datasources/master-datasources.xml:/home/wso2carbon/wso2am-2.1.0/repository/conf/datasources/master-datasources.xml
+      - ./api-manager/carbon/repository/conf/api-manager.xml:/home/wso2carbon/wso2am-2.1.0/repository/conf/api-manager.xml
+      - ./api-manager/carbon/repository/conf/carbon.xml:/home/wso2carbon/wso2am-2.1.0/repository/conf/carbon.xml
+      - ./api-manager/carbon/repository/conf/tomcat/catalina-server.xml:/home/wso2carbon/wso2am-2.1.0/repository/conf/tomcat/catalina-server.xml
     ports:
       - "80:9763"
       - "443:9443"


### PR DESCRIPTION
## Purpose
The username in the Dockerfiles has been updated to `wso2carbon`. Hence the target file path in `docker-compose.yml` file has to be updated. Also, update the mysql jdbc driver.


## Goals
Fix file path inconsistency in docker-compose.yml and update the mysql jdbc driver. 

## Approach

- Update the target file path in docker-compose.yml 
- Update the mysql jdbc driver version to v5.1.45 due to security vulnerabilities in older versions 
- Disable SSL in jdbc connection using property `&amp;useSSL=false` to avoid warnings printed when db operations are performed

The reason to disable SSL is the mysql container generate SSL certs when the container starts up via a [docker-entrypoint.sh](https://github.com/docker-library/mysql/blob/master/5.7/docker-entrypoint.sh#L94) script. Since the docker compose configs are mostly used for trying out purposes, we decided that's it's fine to disable SSL for jdbc connections. 
