### PR TITLE
Add files folder required for Docker image builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,5 @@ hs_err_pid*
 *.iml
 
 rat.txt
-#**/files/*
+**/files/*
 

--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,5 @@ hs_err_pid*
 *.iml
 
 rat.txt
-**/files/*
+#**/files/*
 


### PR DESCRIPTION
## Purpose
> The `dockerfiles/apim/files` and  `dockerfiles/is-as-km/files` folders are missing. These need to be added to 2.5.x branch.

## Goals
> Add files folder required for Docker image builds.