### PR TITLE
Use AdoptOpenJDK 8 in WSO2 API Manager and related product Docker resources

### DIFF
--- a/dockerfiles/alpine/apim-analytics/README.md
+++ b/dockerfiles/alpine/apim-analytics/README.md
@@ -23,11 +23,11 @@ git clone https://github.com/wso2/docker-apim.git
 
 - Download the [WSO2 API Manager Analytics 2.6.0](https://wso2.com/api-management/install/analytics/)
 and extract it to `<ANALYTICS_DOCKERFILE_HOME>/base/files`.
-- Download [MySQL Connector/J](https://dev.mysql.com/downloads/connector/j/) v5.1.45 and then copy that to `<ANALYTICS_DOCKERFILE_HOME>/base/files` folder <br>
+- Download [MySQL Connector/J](https://downloads.mysql.com/archives/c-j) and then copy that to `<ANALYTICS_DOCKERFILE_HOME>/base/files` folder <br>
 - Once all of these are in place, it should look as follows:
 
   ```bash
-  <ANALYTICS_DOCKERFILE_HOME>/base/files/mysql-connector-java-5.1.45-bin.jar
+  <ANALYTICS_DOCKERFILE_HOME>/base/files/mysql-connector-java-<version>-bin.jar
   <ANALYTICS_DOCKERFILE_HOME>/base/files/wso2am-analytics-2.6.0/
   ```
 

--- a/dockerfiles/alpine/apim-analytics/README.md
+++ b/dockerfiles/alpine/apim-analytics/README.md
@@ -19,7 +19,7 @@ git clone https://github.com/wso2/docker-apim.git
 
 >The local copy of the `dockerfile/alpine/apim-analytics` directory will be referred to as `ANALYTICS_DOCKERFILE_HOME` from this point onwards.
 
-##### 2. Add WSO2 API Manager Analytics distributions and MySQL Connector to `<ANALYTICS_DOCKERFILE_HOME>`.
+##### 2. Add WSO2 API Manager Analytics distribution and MySQL Connector to `<ANALYTICS_DOCKERFILE_HOME>`.
 
 - Download the [WSO2 API Manager Analytics 2.6.0](https://wso2.com/api-management/install/analytics/)
 and extract it to `<ANALYTICS_DOCKERFILE_HOME>/base/files`.

--- a/dockerfiles/alpine/apim-analytics/base/Dockerfile
+++ b/dockerfiles/alpine/apim-analytics/base/Dockerfile
@@ -16,8 +16,8 @@
 #
 # ------------------------------------------------------------------------
 
-# set to latest Alpine
-FROM openjdk:8u171-jdk-alpine3.8
+# set base Docker image to AdoptOpenJDK Alpine Docker image
+FROM adoptopenjdk/openjdk8:alpine
 MAINTAINER WSO2 Docker Maintainers "dev@wso2.org”
 
 # set user configurations
@@ -73,7 +73,6 @@ RUN mkdir -p ${USER_HOME}/.java/.systemPrefs && \
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_PACK}/ ${WSO2_SERVER_HOME}/
 # copy mysql connector jar to the server as a third party library
 COPY --chown=wso2carbon:wso2 ${FILES}/mysql-connector-java-*-bin.jar ${WSO2_SERVER_HOME}/lib/
-ADD --chown=wso2carbon:wso2 https://repo1.maven.org/maven2/org/xerial/snappy/snappy-java/1.1.1.7/snappy-java-1.1.1.7.jar ${WSO2_SERVER_HOME}/lib/
 
 # set environment variables
 ENV WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER_PACK} \

--- a/dockerfiles/alpine/apim-analytics/base/Dockerfile
+++ b/dockerfiles/alpine/apim-analytics/base/Dockerfile
@@ -44,9 +44,7 @@ ARG MOTD='printf "\n\
  Read more about EULA 2.0 here @ https://wso2.com/licenses/wso2-update/2.0 \n"'
 
 # install required packages
-RUN  apk add --update --no-cache \
-     curl \
-     netcat-openbsd && \
+RUN  apk add --update --no-cache netcat-openbsd && \
      rm -rf /var/cache/apk/*
 
 # create a user group and a user
@@ -69,7 +67,7 @@ RUN mkdir -p ${USER_HOME}/.java/.systemPrefs && \
     chmod -R 755 ${USER_HOME}/.java && \
     chown -R ${USER}:${USER_GROUP} ${USER_HOME}/.java
 
-# copy wso2 product distribution zip file to user's home directory and set ownership
+# copy wso2 product distribution to user's home directory and set ownership
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_PACK}/ ${WSO2_SERVER_HOME}/
 # copy mysql connector jar to the server as a third party library
 COPY --chown=wso2carbon:wso2 ${FILES}/mysql-connector-java-*-bin.jar ${WSO2_SERVER_HOME}/lib/

--- a/dockerfiles/alpine/apim-analytics/base/Dockerfile
+++ b/dockerfiles/alpine/apim-analytics/base/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Alpine Docker image
-FROM adoptopenjdk/openjdk8:alpine
+FROM adoptopenjdk/openjdk8:jdk8u192-b12-alpine
 MAINTAINER WSO2 Docker Maintainers "dev@wso2.org”
 
 # set user configurations

--- a/dockerfiles/alpine/apim-analytics/base/Dockerfile
+++ b/dockerfiles/alpine/apim-analytics/base/Dockerfile
@@ -69,7 +69,7 @@ RUN mkdir -p ${USER_HOME}/.java/.systemPrefs && \
     chmod -R 755 ${USER_HOME}/.java && \
     chown -R ${USER}:${USER_GROUP} ${USER_HOME}/.java
 
-# copy wso2 product distribution zip files to user's home directory and set ownership
+# copy wso2 product distribution zip file to user's home directory and set ownership
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_PACK}/ ${WSO2_SERVER_HOME}/
 # copy mysql connector jar to the server as a third party library
 COPY --chown=wso2carbon:wso2 ${FILES}/mysql-connector-java-*-bin.jar ${WSO2_SERVER_HOME}/lib/

--- a/dockerfiles/alpine/apim-analytics/dashboard/Dockerfile
+++ b/dockerfiles/alpine/apim-analytics/dashboard/Dockerfile
@@ -26,4 +26,4 @@ COPY --chown=wso2carbon:wso2 init.sh ${WORKING_DIRECTORY}/
 EXPOSE 9713 9643 9613 7713 7613
 
 # start WSO2 Carbon server
-ENTRYPOINT ${WORKING_DIRECTORY}/init.sh
+ENTRYPOINT ["/home/wso2carbon/init.sh"]

--- a/dockerfiles/alpine/apim-analytics/dashboard/init.sh
+++ b/dockerfiles/alpine/apim-analytics/dashboard/init.sh
@@ -68,4 +68,4 @@ test -d ${config_volume}/ && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
 test -d ${artifact_volume}/ && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
 # start WSO2 Carbon server
-sh ${WSO2_SERVER_HOME}/bin/dashboard.sh
+sh ${WSO2_SERVER_HOME}/bin/dashboard.sh "$@"

--- a/dockerfiles/alpine/apim-analytics/worker/Dockerfile
+++ b/dockerfiles/alpine/apim-analytics/worker/Dockerfile
@@ -26,4 +26,4 @@ COPY --chown=wso2carbon:wso2 init.sh ${WORKING_DIRECTORY}/
 EXPOSE 9091 9444 7712 7612 9613 9713 7444 7071
 
 # start WSO2 Carbon server
-ENTRYPOINT ${WORKING_DIRECTORY}/init.sh
+ENTRYPOINT ["/home/wso2carbon/init.sh"]

--- a/dockerfiles/alpine/apim-analytics/worker/init.sh
+++ b/dockerfiles/alpine/apim-analytics/worker/init.sh
@@ -68,4 +68,4 @@ test -d ${config_volume}/ && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
 test -d ${artifact_volume}/ && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
 # start WSO2 Carbon server
-sh ${WSO2_SERVER_HOME}/bin/worker.sh
+sh ${WSO2_SERVER_HOME}/bin/worker.sh "$@"

--- a/dockerfiles/alpine/apim/Dockerfile
+++ b/dockerfiles/alpine/apim/Dockerfile
@@ -63,7 +63,7 @@ RUN mkdir -p ${USER_HOME}/.java/.systemPrefs && \
     chmod -R 755 ${USER_HOME}/.java && \
     chown -R ${USER}:${USER_GROUP} ${USER_HOME}/.java
 
-# copy wso2 product distribution zip file to user's home directory and set ownership
+# copy wso2 product distribution to user's home directory and set ownership
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_PACK}/ ${WSO2_SERVER_HOME}/
 # copy shared artifacts to a temporary location
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_PACK}/repository/deployment/server/ ${USER_HOME}/wso2-tmp/server/

--- a/dockerfiles/alpine/apim/Dockerfile
+++ b/dockerfiles/alpine/apim/Dockerfile
@@ -16,8 +16,8 @@
 #
 # ------------------------------------------------------------------------
 
-# set to latest Alpine
-FROM openjdk:8u171-jdk-alpine3.8
+# set base Docker image to AdoptOpenJDK Alpine Docker image
+FROM adoptopenjdk/openjdk8:alpine
 MAINTAINER WSO2 Docker Maintainers "dev@wso2.org”
 
 # set user configurations
@@ -88,4 +88,4 @@ WORKDIR ${USER_HOME}
 EXPOSE 8280 8243 9763 9443 9099 5672 9711 9611 7711 7611 10397
 
 # initiate container and start WSO2 Carbon server
-ENTRYPOINT ${WORKING_DIRECTORY}/init.sh
+ENTRYPOINT ["/home/wso2carbon/init.sh"]

--- a/dockerfiles/alpine/apim/Dockerfile
+++ b/dockerfiles/alpine/apim/Dockerfile
@@ -63,7 +63,7 @@ RUN mkdir -p ${USER_HOME}/.java/.systemPrefs && \
     chmod -R 755 ${USER_HOME}/.java && \
     chown -R ${USER}:${USER_GROUP} ${USER_HOME}/.java
 
-# copy wso2 product distribution zip files to user's home directory and set ownership
+# copy wso2 product distribution zip file to user's home directory and set ownership
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_PACK}/ ${WSO2_SERVER_HOME}/
 # copy shared artifacts to a temporary location
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_PACK}/repository/deployment/server/ ${USER_HOME}/wso2-tmp/server/

--- a/dockerfiles/alpine/apim/Dockerfile
+++ b/dockerfiles/alpine/apim/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Alpine Docker image
-FROM adoptopenjdk/openjdk8:alpine
+FROM adoptopenjdk/openjdk8:jdk8u192-b12-alpine
 MAINTAINER WSO2 Docker Maintainers "dev@wso2.org”
 
 # set user configurations

--- a/dockerfiles/alpine/apim/README.md
+++ b/dockerfiles/alpine/apim/README.md
@@ -14,7 +14,7 @@ git clone https://github.com/wso2/docker-apim.git
 
 >The local copy of the `dockerfiles/alpine/apim` directory will be referred to as `AM_DOCKERFILE_HOME` from this point onwards.
 
-##### 2. Add WSO2 API Manager distributions and MySQL connector to `<AM_DOCKERFILE_HOME>/files`.
+##### 2. Add WSO2 API Manager distribution and MySQL connector to `<AM_DOCKERFILE_HOME>/files`.
 
 - Download [WSO2 API Manager v2.6.0](https://wso2.com/api-management/)
 distribution and extract it to `<AM_DOCKERFILE_HOME>/files`.

--- a/dockerfiles/alpine/apim/README.md
+++ b/dockerfiles/alpine/apim/README.md
@@ -23,7 +23,7 @@ and copy that to `<AM_DOCKERFILE_HOME>/files`.
 - Once all of these are in place, it should look as follows:
 
   ```bash
-  <AM_DOCKERFILE_HOME>/files/jdk<version>/
+  <AM_DOCKERFILE_HOME>/files/mysql-connector-java-5.1.45-bin.jar
   <AM_DOCKERFILE_HOME>/files/wso2am-2.6.0/
   ```
   

--- a/dockerfiles/alpine/apim/README.md
+++ b/dockerfiles/alpine/apim/README.md
@@ -18,12 +18,12 @@ git clone https://github.com/wso2/docker-apim.git
 
 - Download [WSO2 API Manager v2.6.0](https://wso2.com/api-management/)
 distribution and extract it to `<AM_DOCKERFILE_HOME>/files`.
-- Download [MySQL Connector JAR v5.1.45](https://downloads.mysql.com/archives/c-j)
+- Download [MySQL Connector/J](https://downloads.mysql.com/archives/c-j)
 and copy that to `<AM_DOCKERFILE_HOME>/files`.
 - Once all of these are in place, it should look as follows:
 
   ```bash
-  <AM_DOCKERFILE_HOME>/files/mysql-connector-java-5.1.45-bin.jar
+  <AM_DOCKERFILE_HOME>/files/mysql-connector-java-<version>-bin.jar
   <AM_DOCKERFILE_HOME>/files/wso2am-2.6.0/
   ```
   

--- a/dockerfiles/alpine/apim/init.sh
+++ b/dockerfiles/alpine/apim/init.sh
@@ -87,4 +87,4 @@ test -d ${artifact_volume}/ && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 sed -i "s#<parameter\ name=\"localMemberHost\".*<\/parameter>#<parameter\ name=\"localMemberHost\">${docker_container_ip}<\/parameter>#" ${WSO2_SERVER_HOME}/repository/conf/axis2/axis2.xml
 
 # start WSO2 Carbon server
-sh ${WSO2_SERVER_HOME}/bin/wso2server.sh
+sh ${WSO2_SERVER_HOME}/bin/wso2server.sh "$@"

--- a/dockerfiles/alpine/is-as-km/Dockerfile
+++ b/dockerfiles/alpine/is-as-km/Dockerfile
@@ -16,8 +16,8 @@
 #
 # ------------------------------------------------------------------------
 
-# set to latest Alpine
-FROM openjdk:8u171-jdk-alpine3.8
+# set base Docker image to AdoptOpenJDK Alpine Docker image
+FROM adoptopenjdk/openjdk8:alpine
 MAINTAINER WSO2 Docker Maintainers "dev@wso2.org”
 
 # set user configurations
@@ -88,4 +88,4 @@ WORKDIR ${USER_HOME}
 EXPOSE 9763 9443
 
 # initiate container and start WSO2 Carbon server
-ENTRYPOINT ${WORKING_DIRECTORY}/init.sh
+ENTRYPOINT ["/home/wso2carbon/init.sh"]

--- a/dockerfiles/alpine/is-as-km/Dockerfile
+++ b/dockerfiles/alpine/is-as-km/Dockerfile
@@ -56,7 +56,7 @@ RUN  addgroup -g ${USER_GROUP_ID} ${USER_GROUP}; \
 # MOTD login message
 RUN echo $MOTD > "$ENV"
 
-# copy wso2 product distribution zip file to user's home directory and set ownership
+# copy wso2 product distribution to user's home directory and set ownership
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_PACK} ${WSO2_SERVER_HOME}/
 # copy shared artifacts to a temporary location
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_PACK}/repository/deployment/ ${USER_HOME}/wso2-tmp/deployment/

--- a/dockerfiles/alpine/is-as-km/Dockerfile
+++ b/dockerfiles/alpine/is-as-km/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Alpine Docker image
-FROM adoptopenjdk/openjdk8:alpine
+FROM adoptopenjdk/openjdk8:jdk8u192-b12-alpine
 MAINTAINER WSO2 Docker Maintainers "dev@wso2.org”
 
 # set user configurations

--- a/dockerfiles/alpine/is-as-km/Dockerfile
+++ b/dockerfiles/alpine/is-as-km/Dockerfile
@@ -56,7 +56,7 @@ RUN  addgroup -g ${USER_GROUP_ID} ${USER_GROUP}; \
 # MOTD login message
 RUN echo $MOTD > "$ENV"
 
-# copy wso2 product distribution zip files to user's home directory and set ownership
+# copy wso2 product distribution zip file to user's home directory and set ownership
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_PACK} ${WSO2_SERVER_HOME}/
 # copy shared artifacts to a temporary location
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_PACK}/repository/deployment/ ${USER_HOME}/wso2-tmp/deployment/

--- a/dockerfiles/alpine/is-as-km/README.md
+++ b/dockerfiles/alpine/is-as-km/README.md
@@ -15,7 +15,7 @@ git clone https://github.com/wso2/docker-apim.git
 >The local copy of the `dockerfiles/alpine/is-as-km` directory will be referred to as `IS_KM_DOCKERFILE_HOME` from this point onwards.
 
 
-##### 2. Add WSO2 Identity Server as Key Manager distributions and MySQL connector to `<IS_KM_DOCKERFILE_HOME>/files`.
+##### 2. Add WSO2 Identity Server as Key Manager distribution and MySQL connector to `<IS_KM_DOCKERFILE_HOME>/files`.
 
 - Download [WSO2 Identity Server as Key Manager v5.7.0](https://wso2.com/api-management/install/key-manager/)
 distribution and extract it to `<IS_KM_DOCKERFILE_HOME>/files`.

--- a/dockerfiles/alpine/is-as-km/README.md
+++ b/dockerfiles/alpine/is-as-km/README.md
@@ -24,7 +24,7 @@ and copy that to `<IS_KM_DOCKERFILE_HOME>/files`.
 - Once all of these are in place, it should look as follows:
 
     ```bash
-    <IS_KM_DOCKERFILE_HOME>/files/jdk<version>/
+    <IS_KM_DOCKERFILE_HOME>/files/mysql-connector-java-5.1.45-bin.jar
     <IS_KM_DOCKERFILE_HOME>/files/wso2is-km-5.7.0/
     ```
     

--- a/dockerfiles/alpine/is-as-km/README.md
+++ b/dockerfiles/alpine/is-as-km/README.md
@@ -19,12 +19,12 @@ git clone https://github.com/wso2/docker-apim.git
 
 - Download [WSO2 Identity Server as Key Manager v5.7.0](https://wso2.com/api-management/install/key-manager/)
 distribution and extract it to `<IS_KM_DOCKERFILE_HOME>/files`.
-- Download [MySQL Connector JAR v5.1.45](https://downloads.mysql.com/archives/c-j)
+- Download [MySQL Connector/J](https://downloads.mysql.com/archives/c-j)
 and copy that to `<IS_KM_DOCKERFILE_HOME>/files`.
 - Once all of these are in place, it should look as follows:
 
     ```bash
-    <IS_KM_DOCKERFILE_HOME>/files/mysql-connector-java-5.1.45-bin.jar
+    <IS_KM_DOCKERFILE_HOME>/files/mysql-connector-java-<version>-bin.jar
     <IS_KM_DOCKERFILE_HOME>/files/wso2is-km-5.7.0/
     ```
     

--- a/dockerfiles/alpine/is-as-km/init.sh
+++ b/dockerfiles/alpine/is-as-km/init.sh
@@ -87,4 +87,4 @@ test -d ${artifact_volume}/ && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 sed -i "s#<parameter\ name=\"localMemberHost\".*<\/parameter>#<parameter\ name=\"localMemberHost\">${docker_container_ip}<\/parameter>#" ${WSO2_SERVER_HOME}/repository/conf/axis2/axis2.xml
 
 # start WSO2 Carbon server
-sh ${WSO2_SERVER_HOME}/bin/wso2server.sh
+sh ${WSO2_SERVER_HOME}/bin/wso2server.sh "$@"

--- a/dockerfiles/centos/apim-analytics/README.md
+++ b/dockerfiles/centos/apim-analytics/README.md
@@ -24,12 +24,12 @@ git clone https://github.com/wso2/docker-apim.git
 - Download [AdoptOpenJDK 8](https://adoptopenjdk.net/) and extract it to `<ANALYTICS_DOCKERFILE_HOME>/files`.
 - Download the [WSO2 API Manager Analytics 2.6.0](https://wso2.com/api-management/install/analytics/)
 and extract it to `<ANALYTICS_DOCKERFILE_HOME>/base/files`.
-- Download [MySQL Connector/J](https://dev.mysql.com/downloads/connector/j/) v5.1.45 and then copy that to `<ANALYTICS_DOCKERFILE_HOME>/base/files` folder <br>
+- Download [MySQL Connector/J](https://downloads.mysql.com/archives/c-j) and then copy that to `<ANALYTICS_DOCKERFILE_HOME>/base/files` folder <br>
 - Once all of these are in place, it should look as follows:
 
   ```bash
   <ANALYTICS_DOCKERFILE_HOME>/base/files/jdk8u<version>/
-  <ANALYTICS_DOCKERFILE_HOME>/base/files/mysql-connector-java-5.1.45-bin.jar
+  <ANALYTICS_DOCKERFILE_HOME>/base/files/mysql-connector-java-<version>-bin.jar
   <ANALYTICS_DOCKERFILE_HOME>/base/files/wso2am-analytics-2.6.0/
   ```
 

--- a/dockerfiles/centos/apim-analytics/README.md
+++ b/dockerfiles/centos/apim-analytics/README.md
@@ -21,15 +21,14 @@ git clone https://github.com/wso2/docker-apim.git
 
 ##### 2. Add JDK, WSO2 API Manager Analytics distributions and MySQL Connector to `<ANALYTICS_DOCKERFILE_HOME>`.
 
-- Download [JDK v1.8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) 
-and extract it to `<ANALYTICS_DOCKERFILE_HOME>/base/files`.
+- Download [AdoptOpenJDK 8](https://adoptopenjdk.net/) and extract it to `<ANALYTICS_DOCKERFILE_HOME>/files`.
 - Download the [WSO2 API Manager Analytics 2.6.0](https://wso2.com/api-management/install/analytics/)
 and extract it to `<ANALYTICS_DOCKERFILE_HOME>/base/files`.
 - Download [MySQL Connector/J](https://dev.mysql.com/downloads/connector/j/) v5.1.45 and then copy that to `<ANALYTICS_DOCKERFILE_HOME>/base/files` folder <br>
 - Once all of these are in place, it should look as follows:
 
   ```bash
-  <ANALYTICS_DOCKERFILE_HOME>/base/files/jdk<version>/
+  <ANALYTICS_DOCKERFILE_HOME>/base/files/jdk8u<version>/
   <ANALYTICS_DOCKERFILE_HOME>/base/files/mysql-connector-java-5.1.45-bin.jar
   <ANALYTICS_DOCKERFILE_HOME>/base/files/wso2am-analytics-2.6.0/
   ```

--- a/dockerfiles/centos/apim-analytics/base/Dockerfile
+++ b/dockerfiles/centos/apim-analytics/base/Dockerfile
@@ -29,7 +29,7 @@ ARG USER_HOME=/home/${USER}
 # set dependant files directory
 ARG FILES=./files
 # set jdk configurations
-ARG JDK=jdk1.8.0*
+ARG JDK=jdk8u*
 ARG JAVA_HOME=${USER_HOME}/java
 # set wso2 product configurations
 ARG WSO2_SERVER=wso2am-analytics

--- a/dockerfiles/centos/apim-analytics/dashboard/Dockerfile
+++ b/dockerfiles/centos/apim-analytics/dashboard/Dockerfile
@@ -26,4 +26,4 @@ COPY --chown=wso2carbon:wso2 init.sh ${WORKING_DIRECTORY}/
 EXPOSE 9713 9643 9613 7713 7613
 
 # start WSO2 Carbon server
-ENTRYPOINT ${WORKING_DIRECTORY}/init.sh
+ENTRYPOINT ["/home/wso2carbon/init.sh"]

--- a/dockerfiles/centos/apim-analytics/dashboard/init.sh
+++ b/dockerfiles/centos/apim-analytics/dashboard/init.sh
@@ -68,4 +68,4 @@ test -d ${config_volume}/ && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
 test -d ${artifact_volume}/ && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
 # start WSO2 Carbon server
-sh ${WSO2_SERVER_HOME}/bin/dashboard.sh
+sh ${WSO2_SERVER_HOME}/bin/dashboard.sh "$@"

--- a/dockerfiles/centos/apim-analytics/worker/Dockerfile
+++ b/dockerfiles/centos/apim-analytics/worker/Dockerfile
@@ -26,4 +26,4 @@ COPY --chown=wso2carbon:wso2 init.sh ${WORKING_DIRECTORY}/
 EXPOSE 9091 9444 7712 7612 9613 9713 7444 7071
 
 # start WSO2 Carbon server
-ENTRYPOINT ${WORKING_DIRECTORY}/init.sh
+ENTRYPOINT ["/home/wso2carbon/init.sh"]

--- a/dockerfiles/centos/apim-analytics/worker/init.sh
+++ b/dockerfiles/centos/apim-analytics/worker/init.sh
@@ -68,4 +68,4 @@ test -d ${config_volume}/ && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
 test -d ${artifact_volume}/ && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
 # start WSO2 Carbon server
-sh ${WSO2_SERVER_HOME}/bin/worker.sh
+sh ${WSO2_SERVER_HOME}/bin/worker.sh "$@"

--- a/dockerfiles/centos/apim/Dockerfile
+++ b/dockerfiles/centos/apim/Dockerfile
@@ -29,7 +29,7 @@ ARG USER_HOME=/home/${USER}
 # set dependant files directory
 ARG FILES=./files
 # set jdk configurations
-ARG JDK=jdk1.8.0*
+ARG JDK=jdk8u*
 ARG JAVA_HOME=${USER_HOME}/java
 # set wso2 product configurations
 ARG WSO2_SERVER=wso2am
@@ -43,6 +43,7 @@ ARG MOTD='printf "\n\
  This Docker container comprises of a WSO2 product, running with its latest updates \n\
  which are under the End User License Agreement (EULA) 2.0. \n\
  Read more about EULA 2.0 here @ https://wso2.com/licenses/wso2-update/2.0 \n"'
+
 # install required packages
 RUN yum -y update && \
     yum install -y nc && \
@@ -80,4 +81,4 @@ ENV JAVA_HOME=${JAVA_HOME} \
 EXPOSE 8280 8243 9763 9443 9099 5672 9711 9611 7711 7611 10397
 
 # initiate container and start WSO2 Carbon server
-ENTRYPOINT ${WORKING_DIRECTORY}/init.sh
+ENTRYPOINT ["/home/wso2carbon/init.sh"]

--- a/dockerfiles/centos/apim/README.md
+++ b/dockerfiles/centos/apim/README.md
@@ -16,16 +16,14 @@ git clone https://github.com/wso2/docker-apim.git
 
 ##### 2. Add JDK, WSO2 API Manager distributions and MySQL connector to `<AM_DOCKERFILE_HOME>/files`.
 
-- Download [JDK v1.8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
-and extract it to `<AM_DOCKERFILE_HOME>/files`.
-- Download [WSO2 API Manager v2.6.0](https://wso2.com/api-management/)
-distribution and extract it to `<AM_DOCKERFILE_HOME>/files`.
-- Download [MySQL Connector JAR v5.1.45](https://downloads.mysql.com/archives/c-j)
-and copy that to `<AM_DOCKERFILE_HOME>/files`.
+- Download [AdoptOpenJDK 8](https://adoptopenjdk.net/) and extract it to `<AM_DOCKERFILE_HOME>/files`.
+- Download [WSO2 API Manager v2.6.0](https://wso2.com/api-management/) distribution and extract it to `<AM_DOCKERFILE_HOME>/files`.
+- Download [MySQL Connector JAR v5.1.45](https://downloads.mysql.com/archives/c-j) and copy that to `<AM_DOCKERFILE_HOME>/files`.
 - Once all of these are in place, it should look as follows:
 
   ```bash
-  <AM_DOCKERFILE_HOME>/files/jdk<version>/
+  <AM_DOCKERFILE_HOME>/files/jdk8u<version>/
+  <AM_DOCKERFILE_HOME>/files/mysql-connector-java-5.1.45-bin.jar
   <AM_DOCKERFILE_HOME>/files/wso2am-2.6.0/
   ```
   

--- a/dockerfiles/centos/apim/README.md
+++ b/dockerfiles/centos/apim/README.md
@@ -18,12 +18,12 @@ git clone https://github.com/wso2/docker-apim.git
 
 - Download [AdoptOpenJDK 8](https://adoptopenjdk.net/) and extract it to `<AM_DOCKERFILE_HOME>/files`.
 - Download [WSO2 API Manager v2.6.0](https://wso2.com/api-management/) distribution and extract it to `<AM_DOCKERFILE_HOME>/files`.
-- Download [MySQL Connector JAR v5.1.45](https://downloads.mysql.com/archives/c-j) and copy that to `<AM_DOCKERFILE_HOME>/files`.
+- Download [MySQL Connector/J](https://downloads.mysql.com/archives/c-j) and copy that to `<AM_DOCKERFILE_HOME>/files`.
 - Once all of these are in place, it should look as follows:
 
   ```bash
   <AM_DOCKERFILE_HOME>/files/jdk8u<version>/
-  <AM_DOCKERFILE_HOME>/files/mysql-connector-java-5.1.45-bin.jar
+  <AM_DOCKERFILE_HOME>/files/mysql-connector-java-<version>-bin.jar
   <AM_DOCKERFILE_HOME>/files/wso2am-2.6.0/
   ```
   

--- a/dockerfiles/centos/apim/init.sh
+++ b/dockerfiles/centos/apim/init.sh
@@ -87,4 +87,4 @@ test -d ${artifact_volume}/ && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 sed -i "s#<parameter\ name=\"localMemberHost\".*<\/parameter>#<parameter\ name=\"localMemberHost\">${docker_container_ip}<\/parameter>#" ${WSO2_SERVER_HOME}/repository/conf/axis2/axis2.xml
 
 # start WSO2 Carbon server
-sh ${WSO2_SERVER_HOME}/bin/wso2server.sh
+sh ${WSO2_SERVER_HOME}/bin/wso2server.sh "$@"

--- a/dockerfiles/centos/is-as-km/Dockerfile
+++ b/dockerfiles/centos/is-as-km/Dockerfile
@@ -29,7 +29,7 @@ ARG USER_HOME=/home/${USER}
 # set dependant files directory
 ARG FILES=./files
 # set jdk configurations
-ARG JDK=jdk1.8.0*
+ARG JDK=jdk8u*
 ARG JAVA_HOME=${USER_HOME}/java
 # set wso2 product configurations
 ARG WSO2_SERVER=wso2is-km
@@ -80,4 +80,4 @@ ENV JAVA_HOME=${JAVA_HOME} \
 EXPOSE 9763 9443
 
 # initiate container and start WSO2 Carbon server
-ENTRYPOINT ${WORKING_DIRECTORY}/init.sh
+ENTRYPOINT ["/home/wso2carbon/init.sh"]

--- a/dockerfiles/centos/is-as-km/README.md
+++ b/dockerfiles/centos/is-as-km/README.md
@@ -20,13 +20,13 @@ git clone https://github.com/wso2/docker-apim.git
 - Download [AdoptOpenJDK 8](https://adoptopenjdk.net/) and extract it to `<IS_KM_DOCKERFILE_HOME>/files`.
 - Download [WSO2 Identity Server as Key Manager v5.7.0](https://wso2.com/api-management/install/key-manager/)
 distribution and extract it to `<IS_KM_DOCKERFILE_HOME>/files`.
-- Download [MySQL Connector JAR v5.1.45](https://downloads.mysql.com/archives/c-j)
+- Download [MySQL Connector/J](https://downloads.mysql.com/archives/c-j)
 and copy that to `<IS_KM_DOCKERFILE_HOME>/files`.
 - Once all of these are in place, it should look as follows:
 
     ```bash
     <IS_KM_DOCKERFILE_HOME>/files/jdk8u<version>/
-    <IS_KM_DOCKERFILE_HOME>/files/mysql-connector-java-5.1.45-bin.jar
+    <IS_KM_DOCKERFILE_HOME>/files/mysql-connector-java-<version>-bin.jar
     <IS_KM_DOCKERFILE_HOME>/files/wso2is-km-5.7.0/
     ```
     

--- a/dockerfiles/centos/is-as-km/README.md
+++ b/dockerfiles/centos/is-as-km/README.md
@@ -17,8 +17,7 @@ git clone https://github.com/wso2/docker-apim.git
 
 ##### 2. Add JDK, WSO2 Identity Server as Key Manager distributions and MySQL connector to `<IS_KM_DOCKERFILE_HOME>/files`.
 
-- Download [JDK v1.8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
-and extract it to `<IS_KM_DOCKERFILE_HOME>/files`.
+- Download [AdoptOpenJDK 8](https://adoptopenjdk.net/) and extract it to `<IS_KM_DOCKERFILE_HOME>/files`.
 - Download [WSO2 Identity Server as Key Manager v5.7.0](https://wso2.com/api-management/install/key-manager/)
 distribution and extract it to `<IS_KM_DOCKERFILE_HOME>/files`.
 - Download [MySQL Connector JAR v5.1.45](https://downloads.mysql.com/archives/c-j)
@@ -26,7 +25,8 @@ and copy that to `<IS_KM_DOCKERFILE_HOME>/files`.
 - Once all of these are in place, it should look as follows:
 
     ```bash
-    <IS_KM_DOCKERFILE_HOME>/files/jdk<version>/
+    <IS_KM_DOCKERFILE_HOME>/files/jdk8u<version>/
+    <IS_KM_DOCKERFILE_HOME>/files/mysql-connector-java-5.1.45-bin.jar
     <IS_KM_DOCKERFILE_HOME>/files/wso2is-km-5.7.0/
     ```
     

--- a/dockerfiles/centos/is-as-km/init.sh
+++ b/dockerfiles/centos/is-as-km/init.sh
@@ -87,4 +87,4 @@ test -d ${artifact_volume}/ && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 sed -i "s#<parameter\ name=\"localMemberHost\".*<\/parameter>#<parameter\ name=\"localMemberHost\">${docker_container_ip}<\/parameter>#" ${WSO2_SERVER_HOME}/repository/conf/axis2/axis2.xml
 
 # start WSO2 Carbon server
-sh ${WSO2_SERVER_HOME}/bin/wso2server.sh
+sh ${WSO2_SERVER_HOME}/bin/wso2server.sh "$@"

--- a/dockerfiles/ubuntu/apim-analytics/README.md
+++ b/dockerfiles/ubuntu/apim-analytics/README.md
@@ -19,7 +19,7 @@ git clone https://github.com/wso2/docker-apim.git
 
 >The local copy of the `dockerfile/ubuntu/apim-analytics` directory will be referred to as `ANALYTICS_DOCKERFILE_HOME` from this point onwards.
 
-##### 2. Add WSO2 API Manager Analytics distributions and MySQL Connector to `<ANALYTICS_DOCKERFILE_HOME>`.
+##### 2. Add WSO2 API Manager Analytics distribution and MySQL Connector to `<ANALYTICS_DOCKERFILE_HOME>`.
 
 - Download the [WSO2 API Manager Analytics 2.6.0](https://wso2.com/api-management/install/analytics/)
 and extract it to `<ANALYTICS_DOCKERFILE_HOME>/base/files`.

--- a/dockerfiles/ubuntu/apim-analytics/README.md
+++ b/dockerfiles/ubuntu/apim-analytics/README.md
@@ -23,12 +23,12 @@ git clone https://github.com/wso2/docker-apim.git
 
 - Download the [WSO2 API Manager Analytics 2.6.0](https://wso2.com/api-management/install/analytics/)
 and extract it to `<ANALYTICS_DOCKERFILE_HOME>/base/files`.
-- Download [MySQL Connector/J](https://dev.mysql.com/downloads/connector/j/) v5.1.45 and then copy that to `<ANALYTICS_DOCKERFILE_HOME>/base/files` folder <br>
+- Download [MySQL Connector/J](https://downloads.mysql.com/archives/c-j) and then copy that to `<ANALYTICS_DOCKERFILE_HOME>/base/files` folder <br>
 - Once all of these are in place, it should look as follows:
 
   ```bash
   <ANALYTICS_DOCKERFILE_HOME>/base/files/wso2am-analytics-2.6.0/
-  <ANALYTICS_DOCKERFILE_HOME>/base/files/mysql-connector-java-5.1.45-bin.jar
+  <ANALYTICS_DOCKERFILE_HOME>/base/files/mysql-connector-java-<version>-bin.jar
   ```
 
 >Please refer to [WSO2 Update Manager documentation](https://docs.wso2.com/display/WUM300/WSO2+Update+Manager)

--- a/dockerfiles/ubuntu/apim-analytics/README.md
+++ b/dockerfiles/ubuntu/apim-analytics/README.md
@@ -19,17 +19,14 @@ git clone https://github.com/wso2/docker-apim.git
 
 >The local copy of the `dockerfile/ubuntu/apim-analytics` directory will be referred to as `ANALYTICS_DOCKERFILE_HOME` from this point onwards.
 
-##### 2. Add JDK, WSO2 API Manager Analytics distributions and MySQL Connector to `<ANALYTICS_DOCKERFILE_HOME>`.
+##### 2. Add WSO2 API Manager Analytics distributions and MySQL Connector to `<ANALYTICS_DOCKERFILE_HOME>`.
 
-- Download [JDK v1.8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) 
-and extract it to `<ANALYTICS_DOCKERFILE_HOME>/base/files`.
 - Download the [WSO2 API Manager Analytics 2.6.0](https://wso2.com/api-management/install/analytics/)
 and extract it to `<ANALYTICS_DOCKERFILE_HOME>/base/files`.
 - Download [MySQL Connector/J](https://dev.mysql.com/downloads/connector/j/) v5.1.45 and then copy that to `<ANALYTICS_DOCKERFILE_HOME>/base/files` folder <br>
 - Once all of these are in place, it should look as follows:
 
   ```bash
-  <ANALYTICS_DOCKERFILE_HOME>/base/files/jdk<version>/
   <ANALYTICS_DOCKERFILE_HOME>/base/files/mysql-connector-java-5.1.45-bin.jar
   <ANALYTICS_DOCKERFILE_HOME>/base/files/wso2am-analytics-2.6.0/
   ```

--- a/dockerfiles/ubuntu/apim-analytics/README.md
+++ b/dockerfiles/ubuntu/apim-analytics/README.md
@@ -27,8 +27,8 @@ and extract it to `<ANALYTICS_DOCKERFILE_HOME>/base/files`.
 - Once all of these are in place, it should look as follows:
 
   ```bash
-  <ANALYTICS_DOCKERFILE_HOME>/base/files/mysql-connector-java-5.1.45-bin.jar
   <ANALYTICS_DOCKERFILE_HOME>/base/files/wso2am-analytics-2.6.0/
+  <ANALYTICS_DOCKERFILE_HOME>/base/files/mysql-connector-java-5.1.45-bin.jar
   ```
 
 >Please refer to [WSO2 Update Manager documentation](https://docs.wso2.com/display/WUM300/WSO2+Update+Manager)

--- a/dockerfiles/ubuntu/apim-analytics/base/Dockerfile
+++ b/dockerfiles/ubuntu/apim-analytics/base/Dockerfile
@@ -43,9 +43,7 @@ Read more about EULA 2.0 (https://wso2.com/licenses/wso2-update/2.0).\n"
 
 # install required packages
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    curl \
-    netcat && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends netcat && \
     rm -rf /var/lib/apt/lists/* && \
     echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
     >> /etc/bash.bashrc \

--- a/dockerfiles/ubuntu/apim-analytics/base/Dockerfile
+++ b/dockerfiles/ubuntu/apim-analytics/base/Dockerfile
@@ -16,8 +16,8 @@
 #
 # ------------------------------------------------------------------------
 
-# set to latest Ubuntu LTS
-FROM ubuntu:18.04
+# set base Docker image to AdoptOpenJDK Ubuntu Docker image
+FROM adoptopenjdk/openjdk8:jdk8u192-b12
 MAINTAINER WSO2 Docker Maintainers "dev@wso2.org"
 
 # set user configurations
@@ -29,7 +29,7 @@ ARG USER_HOME=/home/${USER}
 # set dependant files directory
 ARG FILES=./files
 # set jdk configurations
-ARG JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+ARG JAVA_HOME=/opt/java/openjdk
 # set wso2 product configurations
 ARG WSO2_SERVER=wso2am-analytics
 ARG WSO2_SERVER_VERSION=2.6.0
@@ -46,7 +46,6 @@ Read more about EULA 2.0 (https://wso2.com/licenses/wso2-update/2.0).\n"
 # install required packages
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    openjdk-8-jdk \
     curl \
     netcat && \
     rm -rf /var/lib/apt/lists/* && \
@@ -58,6 +57,13 @@ RUN apt-get update && \
 RUN groupadd --system -g ${USER_GROUP_ID} ${USER_GROUP} && \
     useradd --system --create-home --home-dir ${USER_HOME} --no-log-init -g ${USER_GROUP_ID} -u ${USER_ID} ${USER}
 
+# create java prefs dir
+# this is to avoid warning logs printed by FileSystemPreferences class
+RUN mkdir -p ${USER_HOME}/.java/.systemPrefs && \
+    mkdir -p ${USER_HOME}/.java/.userPrefs  && \
+    chmod -R 755 ${USER_HOME}/.java && \
+    chown -R ${USER}:${USER_GROUP} ${USER_HOME}/.java
+
 # copy the wso2 product distributions to user's home directory
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_PACK}/ ${WSO2_SERVER_HOME}/
 # copy mysql connector jar to the server as a third party library
@@ -68,7 +74,6 @@ USER ${USER_ID}
 WORKDIR ${USER_HOME}
 
 # set environment variables
-ENV JAVA_HOME=${JAVA_HOME} \
-    PATH=$JAVA_HOME/bin:$PATH \
-    WSO2_SERVER_HOME=${WSO2_SERVER_HOME} \
-    WORKING_DIRECTORY=${USER_HOME}
+ENV WSO2_SERVER_HOME=${WSO2_SERVER_HOME} \
+    WORKING_DIRECTORY=${USER_HOME} \
+    JAVA_OPTS="-Djava.util.prefs.systemRoot=${USER_HOME}/.java -Djava.util.prefs.userRoot=${USER_HOME}/.java/.userPrefs"

--- a/dockerfiles/ubuntu/apim-analytics/base/Dockerfile
+++ b/dockerfiles/ubuntu/apim-analytics/base/Dockerfile
@@ -28,8 +28,6 @@ ARG USER_GROUP_ID=802
 ARG USER_HOME=/home/${USER}
 # set dependant files directory
 ARG FILES=./files
-# set jdk configurations
-ARG JAVA_HOME=/opt/java/openjdk
 # set wso2 product configurations
 ARG WSO2_SERVER=wso2am-analytics
 ARG WSO2_SERVER_VERSION=2.6.0

--- a/dockerfiles/ubuntu/apim-analytics/base/Dockerfile
+++ b/dockerfiles/ubuntu/apim-analytics/base/Dockerfile
@@ -29,8 +29,7 @@ ARG USER_HOME=/home/${USER}
 # set dependant files directory
 ARG FILES=./files
 # set jdk configurations
-ARG JDK=jdk1.8.0*
-ARG JAVA_HOME=${USER_HOME}/java
+ARG JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 # set wso2 product configurations
 ARG WSO2_SERVER=wso2am-analytics
 ARG WSO2_SERVER_VERSION=2.6.0
@@ -47,6 +46,7 @@ Read more about EULA 2.0 (https://wso2.com/licenses/wso2-update/2.0).\n"
 # install required packages
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    openjdk-8-jdk \
     curl \
     netcat && \
     rm -rf /var/lib/apt/lists/* && \
@@ -58,8 +58,7 @@ RUN apt-get update && \
 RUN groupadd --system -g ${USER_GROUP_ID} ${USER_GROUP} && \
     useradd --system --create-home --home-dir ${USER_HOME} --no-log-init -g ${USER_GROUP_ID} -u ${USER_ID} ${USER}
 
-# copy the jdk and wso2 product distributions to user's home directory
-COPY --chown=wso2carbon:wso2 ${FILES}/${JDK} ${USER_HOME}/java/
+# copy the wso2 product distributions to user's home directory
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_PACK}/ ${WSO2_SERVER_HOME}/
 # copy mysql connector jar to the server as a third party library
 COPY --chown=wso2carbon:wso2 ${FILES}/mysql-connector-java-*-bin.jar ${WSO2_SERVER_HOME}/lib/

--- a/dockerfiles/ubuntu/apim-analytics/base/Dockerfile
+++ b/dockerfiles/ubuntu/apim-analytics/base/Dockerfile
@@ -62,7 +62,7 @@ RUN mkdir -p ${USER_HOME}/.java/.systemPrefs && \
     chmod -R 755 ${USER_HOME}/.java && \
     chown -R ${USER}:${USER_GROUP} ${USER_HOME}/.java
 
-# copy the wso2 product distributions to user's home directory
+# copy the wso2 product distribution to user's home directory
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_PACK}/ ${WSO2_SERVER_HOME}/
 # copy mysql connector jar to the server as a third party library
 COPY --chown=wso2carbon:wso2 ${FILES}/mysql-connector-java-*-bin.jar ${WSO2_SERVER_HOME}/lib/

--- a/dockerfiles/ubuntu/apim-analytics/dashboard/Dockerfile
+++ b/dockerfiles/ubuntu/apim-analytics/dashboard/Dockerfile
@@ -26,4 +26,4 @@ COPY --chown=wso2carbon:wso2 init.sh ${WORKING_DIRECTORY}/
 EXPOSE 9713 9643 9613 7713 7613
 
 # start WSO2 Carbon server
-ENTRYPOINT ${WORKING_DIRECTORY}/init.sh
+ENTRYPOINT ["/home/wso2carbon/init.sh"]

--- a/dockerfiles/ubuntu/apim-analytics/dashboard/init.sh
+++ b/dockerfiles/ubuntu/apim-analytics/dashboard/init.sh
@@ -35,4 +35,4 @@ test -d ${config_volume}/ && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
 test -d ${artifact_volume}/ && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
 # start WSO2 Carbon server
-sh ${WSO2_SERVER_HOME}/bin/dashboard.sh
+sh ${WSO2_SERVER_HOME}/bin/dashboard.sh "$@"

--- a/dockerfiles/ubuntu/apim-analytics/worker/Dockerfile
+++ b/dockerfiles/ubuntu/apim-analytics/worker/Dockerfile
@@ -26,4 +26,4 @@ COPY --chown=wso2carbon:wso2 init.sh ${WORKING_DIRECTORY}/
 EXPOSE 9091 9444 7712 7612 9613 9713 7444 7071
 
 # start WSO2 Carbon server
-ENTRYPOINT ${WORKING_DIRECTORY}/init.sh
+ENTRYPOINT ["/home/wso2carbon/init.sh"]

--- a/dockerfiles/ubuntu/apim-analytics/worker/init.sh
+++ b/dockerfiles/ubuntu/apim-analytics/worker/init.sh
@@ -35,4 +35,4 @@ test -d ${config_volume}/ && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
 test -d ${artifact_volume}/ && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
 # start WSO2 Carbon server
-sh ${WSO2_SERVER_HOME}/bin/worker.sh
+sh ${WSO2_SERVER_HOME}/bin/worker.sh "$@"

--- a/dockerfiles/ubuntu/apim/Dockerfile
+++ b/dockerfiles/ubuntu/apim/Dockerfile
@@ -28,8 +28,6 @@ ARG USER_GROUP_ID=802
 ARG USER_HOME=/home/${USER}
 # set dependant files directory
 ARG FILES=./files
-# set jdk configurations
-ARG JAVA_HOME=/opt/java/openjdk
 # set wso2 product configurations
 ARG WSO2_SERVER=wso2am
 ARG WSO2_SERVER_VERSION=2.6.0

--- a/dockerfiles/ubuntu/apim/Dockerfile
+++ b/dockerfiles/ubuntu/apim/Dockerfile
@@ -62,7 +62,7 @@ RUN mkdir -p ${USER_HOME}/.java/.systemPrefs && \
     chmod -R 755 ${USER_HOME}/.java && \
     chown -R ${USER}:${USER_GROUP} ${USER_HOME}/.java
 
-# copy the jdk and wso2 product distributions to user's home directory
+# copy the wso2 product distribution to user's home directory
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_PACK}/ ${WSO2_SERVER_HOME}/
 # copy shared artifacts to a temporary location
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_PACK}/repository/deployment/server/ ${USER_HOME}/wso2-tmp/server/

--- a/dockerfiles/ubuntu/apim/Dockerfile
+++ b/dockerfiles/ubuntu/apim/Dockerfile
@@ -16,8 +16,8 @@
 #
 # ------------------------------------------------------------------------
 
-# set to latest Ubuntu LTS
-FROM ubuntu:18.04
+# set base Docker image to AdoptOpenJDK Ubuntu Docker image
+FROM adoptopenjdk/openjdk8:jdk8u192-b12
 MAINTAINER WSO2 Docker Maintainers "dev@wso2.org"
 
 # set user configurations
@@ -29,7 +29,7 @@ ARG USER_HOME=/home/${USER}
 # set dependant files directory
 ARG FILES=./files
 # set jdk configurations
-ARG JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+ARG JAVA_HOME=/opt/java/openjdk
 # set wso2 product configurations
 ARG WSO2_SERVER=wso2am
 ARG WSO2_SERVER_VERSION=2.6.0
@@ -46,7 +46,6 @@ Read more about EULA 2.0 (https://wso2.com/licenses/wso2-update/2.0).\n"
 # install required packages
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    openjdk-8-jdk \
     curl \
     netcat && \
     rm -rf /var/lib/apt/lists/* && \
@@ -57,6 +56,13 @@ RUN apt-get update && \
 # create a user group and a user
 RUN groupadd --system -g ${USER_GROUP_ID} ${USER_GROUP} && \
     useradd --system --create-home --home-dir ${USER_HOME} --no-log-init -g ${USER_GROUP_ID} -u ${USER_ID} ${USER}
+
+# create java prefs dir
+# this is to avoid warning logs printed by FileSystemPreferences class
+RUN mkdir -p ${USER_HOME}/.java/.systemPrefs && \
+    mkdir -p ${USER_HOME}/.java/.userPrefs  && \
+    chmod -R 755 ${USER_HOME}/.java && \
+    chown -R ${USER}:${USER_GROUP} ${USER_HOME}/.java
 
 # copy the jdk and wso2 product distributions to user's home directory
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_PACK}/ ${WSO2_SERVER_HOME}/
@@ -75,13 +81,12 @@ USER ${USER_ID}
 WORKDIR ${USER_HOME}
 
 # set environment variables
-ENV JAVA_HOME=${JAVA_HOME} \
-    PATH=$JAVA_HOME/bin:$PATH \
-    WSO2_SERVER_HOME=${WSO2_SERVER_HOME} \
-    WORKING_DIRECTORY=${USER_HOME}
+ENV WSO2_SERVER_HOME=${WSO2_SERVER_HOME} \
+    WORKING_DIRECTORY=${USER_HOME} \
+    JAVA_OPTS="-Djava.util.prefs.systemRoot=${USER_HOME}/.java -Djava.util.prefs.userRoot=${USER_HOME}/.java/.userPrefs"
 
 # expose ports
 EXPOSE 8280 8243 9763 9443 9099 5672 9711 9611 7711 7611 10397
 
 # initiate container and start WSO2 Carbon server
-ENTRYPOINT ${WORKING_DIRECTORY}/init.sh
+ENTRYPOINT ["/home/wso2carbon/init.sh"]

--- a/dockerfiles/ubuntu/apim/Dockerfile
+++ b/dockerfiles/ubuntu/apim/Dockerfile
@@ -29,8 +29,7 @@ ARG USER_HOME=/home/${USER}
 # set dependant files directory
 ARG FILES=./files
 # set jdk configurations
-ARG JDK=jdk1.8.0*
-ARG JAVA_HOME=${USER_HOME}/java
+ARG JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 # set wso2 product configurations
 ARG WSO2_SERVER=wso2am
 ARG WSO2_SERVER_VERSION=2.6.0
@@ -47,6 +46,7 @@ Read more about EULA 2.0 (https://wso2.com/licenses/wso2-update/2.0).\n"
 # install required packages
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    openjdk-8-jdk \
     curl \
     netcat && \
     rm -rf /var/lib/apt/lists/* && \
@@ -59,7 +59,6 @@ RUN groupadd --system -g ${USER_GROUP_ID} ${USER_GROUP} && \
     useradd --system --create-home --home-dir ${USER_HOME} --no-log-init -g ${USER_GROUP_ID} -u ${USER_ID} ${USER}
 
 # copy the jdk and wso2 product distributions to user's home directory
-COPY --chown=wso2carbon:wso2 ${FILES}/${JDK} ${USER_HOME}/java/
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_PACK}/ ${WSO2_SERVER_HOME}/
 # copy shared artifacts to a temporary location
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_PACK}/repository/deployment/server/ ${USER_HOME}/wso2-tmp/server/

--- a/dockerfiles/ubuntu/apim/README.md
+++ b/dockerfiles/ubuntu/apim/README.md
@@ -14,7 +14,7 @@ git clone https://github.com/wso2/docker-apim.git
 
 >The local copy of the `dockerfiles/ubuntu/apim` directory will be referred to as `AM_DOCKERFILE_HOME` from this point onwards.
 
-##### 2. Add WSO2 API Manager distributions and MySQL connector to `<AM_DOCKERFILE_HOME>/files`.
+##### 2. Add WSO2 API Manager distribution and MySQL connector to `<AM_DOCKERFILE_HOME>/files`.
 
 - Download [WSO2 API Manager v2.6.0](https://wso2.com/api-management/)
 distribution and extract it to `<AM_DOCKERFILE_HOME>/files`.

--- a/dockerfiles/ubuntu/apim/README.md
+++ b/dockerfiles/ubuntu/apim/README.md
@@ -18,7 +18,7 @@ git clone https://github.com/wso2/docker-apim.git
 
 - Download [WSO2 API Manager v2.6.0](https://wso2.com/api-management/)
 distribution and extract it to `<AM_DOCKERFILE_HOME>/files`.
-- Download [MySQL Connector JAR v5.1.45](https://downloads.mysql.com/archives/c-j)
+- Download [MySQL Connector/J](https://downloads.mysql.com/archives/c-j)
 and copy that to `<AM_DOCKERFILE_HOME>/files`.
 - Once all of these are in place, it should look as follows:
 

--- a/dockerfiles/ubuntu/apim/README.md
+++ b/dockerfiles/ubuntu/apim/README.md
@@ -7,7 +7,7 @@ This section defines the step-by-step instructions to build an [Ubuntu](https://
 
 
 ## How to build an image and run
-##### 1. Checkout this repository into your local machine using the following git command.
+##### 1. Checkout this repository into your local machine using the following Git command.
 ```
 git clone https://github.com/wso2/docker-apim.git
 ```
@@ -24,6 +24,7 @@ and copy that to `<AM_DOCKERFILE_HOME>/files`.
 
   ```bash
   <AM_DOCKERFILE_HOME>/files/wso2am-2.6.0/
+  <AM_DOCKERFILE_HOME>/files/mysql-connector-java-<version>-bin.jar
   ```
   
 >Please refer to [WSO2 Update Manager documentation]( https://docs.wso2.com/display/WUM300/WSO2+Update+Manager)

--- a/dockerfiles/ubuntu/apim/README.md
+++ b/dockerfiles/ubuntu/apim/README.md
@@ -14,10 +14,8 @@ git clone https://github.com/wso2/docker-apim.git
 
 >The local copy of the `dockerfiles/ubuntu/apim` directory will be referred to as `AM_DOCKERFILE_HOME` from this point onwards.
 
-##### 2. Add JDK, WSO2 API Manager distributions and MySQL connector to `<AM_DOCKERFILE_HOME>/files`.
+##### 2. Add WSO2 API Manager distributions and MySQL connector to `<AM_DOCKERFILE_HOME>/files`.
 
-- Download [JDK v1.8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
-and extract it to `<AM_DOCKERFILE_HOME>/files`.
 - Download [WSO2 API Manager v2.6.0](https://wso2.com/api-management/)
 distribution and extract it to `<AM_DOCKERFILE_HOME>/files`.
 - Download [MySQL Connector JAR v5.1.45](https://downloads.mysql.com/archives/c-j)
@@ -25,7 +23,6 @@ and copy that to `<AM_DOCKERFILE_HOME>/files`.
 - Once all of these are in place, it should look as follows:
 
   ```bash
-  <AM_DOCKERFILE_HOME>/files/jdk<version>/
   <AM_DOCKERFILE_HOME>/files/wso2am-2.6.0/
   ```
   

--- a/dockerfiles/ubuntu/apim/init.sh
+++ b/dockerfiles/ubuntu/apim/init.sh
@@ -54,4 +54,4 @@ test -d ${artifact_volume}/ && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 sed -i "s#<parameter\ name=\"localMemberHost\".*<\/parameter>#<parameter\ name=\"localMemberHost\">${docker_container_ip}<\/parameter>#" ${WSO2_SERVER_HOME}/repository/conf/axis2/axis2.xml
 
 # start WSO2 Carbon server
-sh ${WSO2_SERVER_HOME}/bin/wso2server.sh
+sh ${WSO2_SERVER_HOME}/bin/wso2server.sh "$@"

--- a/dockerfiles/ubuntu/is-as-km/Dockerfile
+++ b/dockerfiles/ubuntu/is-as-km/Dockerfile
@@ -29,8 +29,7 @@ ARG USER_HOME=/home/${USER}
 # set dependant files directory
 ARG FILES=./files
 # set jdk configurations
-ARG JDK=jdk1.8.0*
-ARG JAVA_HOME=${USER_HOME}/java
+ARG JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 # set wso2 product configurations
 ARG WSO2_SERVER=wso2is-km
 ARG WSO2_SERVER_VERSION=5.7.0
@@ -47,6 +46,7 @@ Read more about EULA 2.0 (https://wso2.com/licenses/wso2-update/2.0).\n"
 # install required packages
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    openjdk-8-jdk \
     curl \
     netcat && \
     rm -rf /var/lib/apt/lists/* && \
@@ -58,8 +58,7 @@ RUN apt-get update && \
 RUN groupadd --system -g ${USER_GROUP_ID} ${USER_GROUP} && \
     useradd --system --create-home --home-dir ${USER_HOME} --no-log-init -g ${USER_GROUP_ID} -u ${USER_ID} ${USER}
 
-# copy the jdk and wso2 product distributions to user's home directory
-COPY --chown=wso2carbon:wso2 ${FILES}/${JDK} ${USER_HOME}/java/
+# copy the wso2 product distributions to user's home directory
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_PACK}/ ${WSO2_SERVER_HOME}/
 # copy shared artifacts to a temporary location
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_PACK}/repository/deployment/ ${USER_HOME}/wso2-tmp/deployment/

--- a/dockerfiles/ubuntu/is-as-km/Dockerfile
+++ b/dockerfiles/ubuntu/is-as-km/Dockerfile
@@ -62,7 +62,7 @@ RUN mkdir -p ${USER_HOME}/.java/.systemPrefs && \
     chmod -R 755 ${USER_HOME}/.java && \
     chown -R ${USER}:${USER_GROUP} ${USER_HOME}/.java
 
-# copy the wso2 product distributions to user's home directory
+# copy the wso2 product distribution to user's home directory
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_PACK}/ ${WSO2_SERVER_HOME}/
 # copy shared artifacts to a temporary location
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_PACK}/repository/deployment/ ${USER_HOME}/wso2-tmp/deployment/

--- a/dockerfiles/ubuntu/is-as-km/Dockerfile
+++ b/dockerfiles/ubuntu/is-as-km/Dockerfile
@@ -28,8 +28,6 @@ ARG USER_GROUP_ID=802
 ARG USER_HOME=/home/${USER}
 # set dependant files directory
 ARG FILES=./files
-# set jdk configurations
-ARG JAVA_HOME=/opt/java/openjdk
 # set wso2 product configurations
 ARG WSO2_SERVER=wso2is-km
 ARG WSO2_SERVER_VERSION=5.7.0

--- a/dockerfiles/ubuntu/is-as-km/Dockerfile
+++ b/dockerfiles/ubuntu/is-as-km/Dockerfile
@@ -16,8 +16,8 @@
 #
 # ------------------------------------------------------------------------
 
-# set to latest Ubuntu LTS
-FROM ubuntu:18.04
+# set base Docker image to AdoptOpenJDK Ubuntu Docker image
+FROM adoptopenjdk/openjdk8:jdk8u192-b12
 MAINTAINER WSO2 Docker Maintainers "dev@wso2.org"
 
 # set user configurations
@@ -29,7 +29,7 @@ ARG USER_HOME=/home/${USER}
 # set dependant files directory
 ARG FILES=./files
 # set jdk configurations
-ARG JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+ARG JAVA_HOME=/opt/java/openjdk
 # set wso2 product configurations
 ARG WSO2_SERVER=wso2is-km
 ARG WSO2_SERVER_VERSION=5.7.0
@@ -46,7 +46,6 @@ Read more about EULA 2.0 (https://wso2.com/licenses/wso2-update/2.0).\n"
 # install required packages
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    openjdk-8-jdk \
     curl \
     netcat && \
     rm -rf /var/lib/apt/lists/* && \
@@ -57,6 +56,13 @@ RUN apt-get update && \
 # create a user group and a user
 RUN groupadd --system -g ${USER_GROUP_ID} ${USER_GROUP} && \
     useradd --system --create-home --home-dir ${USER_HOME} --no-log-init -g ${USER_GROUP_ID} -u ${USER_ID} ${USER}
+
+# create java prefs dir
+# this is to avoid warning logs printed by FileSystemPreferences class
+RUN mkdir -p ${USER_HOME}/.java/.systemPrefs && \
+    mkdir -p ${USER_HOME}/.java/.userPrefs  && \
+    chmod -R 755 ${USER_HOME}/.java && \
+    chown -R ${USER}:${USER_GROUP} ${USER_HOME}/.java
 
 # copy the wso2 product distributions to user's home directory
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_PACK}/ ${WSO2_SERVER_HOME}/
@@ -75,13 +81,12 @@ USER ${USER_ID}
 WORKDIR ${USER_HOME}
 
 # set environment variables
-ENV JAVA_HOME=${JAVA_HOME} \
-    PATH=$JAVA_HOME/bin:$PATH \
-    WSO2_SERVER_HOME=${WSO2_SERVER_HOME} \
-    WORKING_DIRECTORY=${USER_HOME}
+ENV WSO2_SERVER_HOME=${WSO2_SERVER_HOME} \
+    WORKING_DIRECTORY=${USER_HOME} \
+    JAVA_OPTS="-Djava.util.prefs.systemRoot=${USER_HOME}/.java -Djava.util.prefs.userRoot=${USER_HOME}/.java/.userPrefs"
 
 # expose ports
 EXPOSE 9763 9443
 
 # initiate container and start WSO2 Carbon server
-ENTRYPOINT ${WORKING_DIRECTORY}/init.sh
+ENTRYPOINT ["/home/wso2carbon/init.sh"]

--- a/dockerfiles/ubuntu/is-as-km/README.md
+++ b/dockerfiles/ubuntu/is-as-km/README.md
@@ -25,6 +25,7 @@ and copy that to `<IS_KM_DOCKERFILE_HOME>/files`.
 
     ```bash
     <IS_KM_DOCKERFILE_HOME>/files/wso2is-km-5.7.0/
+    <IS_KM_DOCKERFILE_HOME>/files/mysql-connector-java-<version>-bin.jar
     ```
     
 >Please refer to [WSO2 Update Manager documentation]( https://docs.wso2.com/display/WUM300/WSO2+Update+Manager)

--- a/dockerfiles/ubuntu/is-as-km/README.md
+++ b/dockerfiles/ubuntu/is-as-km/README.md
@@ -15,7 +15,7 @@ git clone https://github.com/wso2/docker-apim.git
 >The local copy of the `dockerfiles/ubuntu/is-as-km` directory will be referred to as `IS_KM_DOCKERFILE_HOME` from this point onwards.
 
 
-##### 2. Add WSO2 Identity Server as Key Manager distributions and MySQL connector to `<IS_KM_DOCKERFILE_HOME>/files`.
+##### 2. Add WSO2 Identity Server as Key Manager distribution and MySQL connector to `<IS_KM_DOCKERFILE_HOME>/files`.
 
 - Download [WSO2 Identity Server as Key Manager v5.7.0](https://wso2.com/api-management/install/key-manager/)
 distribution and extract it to `<IS_KM_DOCKERFILE_HOME>/files`.

--- a/dockerfiles/ubuntu/is-as-km/README.md
+++ b/dockerfiles/ubuntu/is-as-km/README.md
@@ -19,7 +19,7 @@ git clone https://github.com/wso2/docker-apim.git
 
 - Download [WSO2 Identity Server as Key Manager v5.7.0](https://wso2.com/api-management/install/key-manager/)
 distribution and extract it to `<IS_KM_DOCKERFILE_HOME>/files`.
-- Download [MySQL Connector JAR v5.1.45](https://downloads.mysql.com/archives/c-j)
+- Download [MySQL Connector/J](https://downloads.mysql.com/archives/c-j)
 and copy that to `<IS_KM_DOCKERFILE_HOME>/files`.
 - Once all of these are in place, it should look as follows:
 

--- a/dockerfiles/ubuntu/is-as-km/README.md
+++ b/dockerfiles/ubuntu/is-as-km/README.md
@@ -15,10 +15,8 @@ git clone https://github.com/wso2/docker-apim.git
 >The local copy of the `dockerfiles/ubuntu/is-as-km` directory will be referred to as `IS_KM_DOCKERFILE_HOME` from this point onwards.
 
 
-##### 2. Add JDK, WSO2 Identity Server as Key Manager distributions and MySQL connector to `<IS_KM_DOCKERFILE_HOME>/files`.
+##### 2. Add WSO2 Identity Server as Key Manager distributions and MySQL connector to `<IS_KM_DOCKERFILE_HOME>/files`.
 
-- Download [JDK v1.8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
-and extract it to `<IS_KM_DOCKERFILE_HOME>/files`.
 - Download [WSO2 Identity Server as Key Manager v5.7.0](https://wso2.com/api-management/install/key-manager/)
 distribution and extract it to `<IS_KM_DOCKERFILE_HOME>/files`.
 - Download [MySQL Connector JAR v5.1.45](https://downloads.mysql.com/archives/c-j)
@@ -26,7 +24,6 @@ and copy that to `<IS_KM_DOCKERFILE_HOME>/files`.
 - Once all of these are in place, it should look as follows:
 
     ```bash
-    <IS_KM_DOCKERFILE_HOME>/files/jdk<version>/
     <IS_KM_DOCKERFILE_HOME>/files/wso2is-km-5.7.0/
     ```
     

--- a/dockerfiles/ubuntu/is-as-km/init.sh
+++ b/dockerfiles/ubuntu/is-as-km/init.sh
@@ -54,4 +54,4 @@ test -d ${artifact_volume}/ && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 sed -i "s#<parameter\ name=\"localMemberHost\".*<\/parameter>#<parameter\ name=\"localMemberHost\">${docker_container_ip}<\/parameter>#" ${WSO2_SERVER_HOME}/repository/conf/axis2/axis2.xml
 
 # start WSO2 Carbon server
-sh ${WSO2_SERVER_HOME}/bin/wso2server.sh
+sh ${WSO2_SERVER_HOME}/bin/wso2server.sh "$@"


### PR DESCRIPTION
## Purpose
> It is suggested to use AdoptOpenJDK in Docker images for WSO2 API Manager and related products. This PR fixes https://github.com/wso2/docker-apim/issues/177, fixes https://github.com/wso2/docker-apim/issues/178, fixes https://github.com/wso2/docker-apim/issues/185 and fixes https://github.com/wso2/docker-apim/issues/187.

## Goals
> Use AdoptOpenJDK in Alpine, CentOS and Ubuntu based Docker images.