### PR TITLE
Install libxml2-utils Debian package required by API Manager profile startup script

### DIFF
--- a/dockerfiles/ubuntu/apim/Dockerfile
+++ b/dockerfiles/ubuntu/apim/Dockerfile
@@ -48,6 +48,7 @@ Read more about EULA 2.0 (https://wso2.com/licenses/wso2-update/2.0).\n"
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     curl \
+    libxml2-utils \
     netcat && \
     rm -rf /var/lib/apt/lists/* && \
     echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \


### PR DESCRIPTION
## Purpose
> Install libxml2-utils Debian package required by API Manager profile startup script. This fixes https://github.com/wso2/docker-apim/issues/183.

## Goals
> Install libxml2-utils Debian package