### PR TITLE
Integrate support in Docker Compose resources for users with and without WSO2 subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 
 ### Added
-- WSO2 API Manager v2.6.x Docker resources for Alpine, CentOS, Ubuntu
-- WSO2 API Manager Analytics v2.6.x Docker resources for Alpine, CentOS, Ubuntu
-- WSO2 API Manager Identity Server as Key Manager v5.7.x Docker resources for Alpine, CentOS, Ubuntu
+- Integrate support in Docker Compose resources for users with and without WSO2 subscriptions
+
+### Changed
+- Use AdoptOpenJDK version `jdk8u212-b03` in Alpine, CentOS, Ubuntu based Docker resources
+
+## [v2.6.0.2] - 2018-01-11
+
+### Added
+- Integrate support for passing arguments during WSO2 server startup
+
+### Changed
+- Use AdoptOpenJDK version `jdk8u192-b12` in Alpine, CentOS, Ubuntu based Docker resources
+
+## [v2.6.0.1] - 2018-10-09
+
+### Added
+- WSO2 API Manager v2.6.x Docker resources for Alpine, CentOS and Ubuntu
+- WSO2 API Manager Analytics v2.6.x Docker resources for Alpine, CentOS and Ubuntu
+- WSO2 API Manager Identity Server as Key Manager v5.7.x Docker resources for Alpine, CentOS and Ubuntu
 - Docker Compose resources for WSO2 API Management
+
+[v2.6.0.3]: https://github.com/wso2/docker-apim/compare/v2.6.0.2...v2.6.0.3

--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ Docker Compose files have been created according to the most common API Manager 
 product features along side their co-operate API management requirements. The Compose files make use of
 Docker images of WSO2 API Manager, WSO2 API Manager Analytics, WSO2 API Manager Identity Server as Key Manager and MySQL.
 
-**Change log** from previous v2.6.0.1 release: [View Here](CHANGELOG.md)
+**Change log** from previous v2.6.0.2 release: [View Here](CHANGELOG.md)

--- a/docker-compose/apim-is-as-km-with-analytics/README.md
+++ b/docker-compose/apim-is-as-km-with-analytics/README.md
@@ -5,8 +5,9 @@
 
  * Install [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git), [Docker](https://www.docker.com/get-docker) and [Docker Compose](https://docs.docker.com/compose/install/#install-compose)
    in order to run the steps provided in following Quick start guide. <br><br>
- * In order to run this Docker Compose setup, you will need an active subscription from WSO2 since the referring Docker images hosted at docker.wso2.com contains the latest updates and fixes for WSO2 API Manager and
-   API Manager Analytics 2.6.0 and WSO2 Identity Server as KM 5.7.0. You can sign up for a Free Trial Subscription [here](https://wso2.com/free-trial-subscription). <br><br>
+ * In order to use Docker images with WSO2 updates, you need an active WSO2 subscription. If you do not possess an active WSO2
+   subscription, you can sign up for a WSO2 Free Trial Subscription from [here](https://wso2.com/free-trial-subscription).
+   Otherwise, you can proceed with Docker images which are created using GA releases.<br><br>
  * If you wish to run the Docker Compose setup using Docker images built locally, build Docker images using Docker resources available from [here](../../dockerfiles/) and remove the `docker.wso2.com/` prefix from the `image` name in the `docker-compose.yml`. <br><br>
     
 ## Quick Start Guide
@@ -27,15 +28,19 @@
      Instead, extract the zip file and directly browse to `docker-apim-<released-version-here>docker-compose/apim-is-as-km-with-analytics` folder. 
      
     > If you want to try out an already released tag, after executing 2nd step, checkout the relevant tag, 
-     i.e. for example: git checkout tags/v2.6.0.1 and continue below steps.
+     i.e. for example: git checkout tags/v2.6.0.3 and continue below steps.
 
-3. Execute the following Docker Compose command to start the deployment.
+3. [Optional] If you are using WSO2 product Docker images with WSO2 updates, replace the WSO2 product Docker image names
+   (relevant `image` attribute under each WSO2 product profile service) in the Docker Compose deployment definition.
+    
+  **Note**: By default, each product profile service is configured to use WSO2 product Docker images with GA releases.
 
-    ```
-    docker-compose up
-    ```
+4. Execute following Docker Compose command to start the deployment.
+   ```
+   docker-compose up
+   ```
 
-4. Access the WSO2 API Manager web UIs using the below URLs via a web browser.
+5. Access the WSO2 API Manager web UIs using the below URLs via a web browser.
 
  ```
    https://localhost:9443/publisher

--- a/docker-compose/apim-is-as-km-with-analytics/docker-compose.yml
+++ b/docker-compose/apim-is-as-km-with-analytics/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       retries: 5
       start_period: 80s
   am-analytics:
-    image: docker.wso2.com/wso2am-analytics-worker:2.6.0
+    image: wso2/wso2am-analytics-worker:2.6.0
     ports:
       - "9091:9091"
       - "9444:9444"
@@ -32,7 +32,7 @@ services:
     volumes:
       - ./apim-analytics:/home/wso2carbon/wso2-config-volume
   is-as-km:
-    image: docker.wso2.com/wso2is-km:5.7.0
+    image: wso2/wso2is-km:5.7.0
     healthcheck:
       test: ["CMD", "curl", "-k", "-f", "https://localhost:9443/carbon/admin/login.jsp"]
       interval: 10s
@@ -50,7 +50,7 @@ services:
       - "9765:9763"
       - "9445:9443"
   api-manager:
-    image: docker.wso2.com/wso2am:2.6.0
+    image: wso2/wso2am:2.6.0
     healthcheck:
       test: ["CMD", "curl", "-k", "-f", "https://localhost:9443/carbon/admin/login.jsp"]
       interval: 10s

--- a/docker-compose/apim-is-as-km-with-analytics/scripts/README.md
+++ b/docker-compose/apim-is-as-km-with-analytics/scripts/README.md
@@ -30,17 +30,12 @@
     > If you want to try out an already released tag, after executing 2nd step, checkout the relevant tag, 
      i.e. for example: git checkout tags/v2.6.0.3 and continue below steps.
 
-3. [Optional] If you are using WSO2 product Docker images with WSO2 updates, replace the WSO2 product Docker image names
-   (relevant `image` attribute under each WSO2 product profile service) in the Docker Compose deployment definition.
-    
-  **Note**: By default, each product profile service is configured to use WSO2 product Docker images with GA releases.
-
-4. Execute the `deploy.sh` script to start the deployment.
+3. Execute the `deploy.sh` script to start the deployment.
      ```
      ./deploy.sh
      ```
 
-5. Access the WSO2 API Manager web UIs using the below URLs via a web browser.
+4. Access the WSO2 API Manager web UIs using the below URLs via a web browser.
 
  ```
    https://localhost:9443/publisher

--- a/docker-compose/apim-is-as-km-with-analytics/scripts/README.md
+++ b/docker-compose/apim-is-as-km-with-analytics/scripts/README.md
@@ -1,6 +1,5 @@
-# WSO2 API Manager deployment with WSO2 API Manager Analytics
+# WSO2 API Manager with Identity Server as Key Manager
 
-![alt tag](deployment-diagram.png)
 
 ## Prerequisites
 
@@ -10,54 +9,55 @@
    subscription, you can sign up for a WSO2 Free Trial Subscription from [here](https://wso2.com/free-trial-subscription).
    Otherwise, you can proceed with Docker images which are created using GA releases.<br><br>
  * If you wish to run the Docker Compose setup using Docker images built locally, build Docker images using Docker resources available from [here](../../dockerfiles/) and remove the `docker.wso2.com/` prefix from the `image` name in the `docker-compose.yml`. <br><br>
-  
-<br>
-
+    
 ## Quick Start Guide
 
 1. Clone WSO2 API Manager Docker git repository.
 
-   ```
-   git clone https://github.com/wso2/docker-apim
-   ```
-   > If you are to try out an already released zip of this repo, please ignore this 1st step. 
-   
-2. Switch to `docker-compose/apim-with-analytics` folder.
+    ```
+    git clone https://github.com/wso2/docker-apim
+    ```
+    > If you are to try out an already released zip of this repo, please ignore this 1st step. 
 
-   ```
-   cd docker-apim/docker-compose/apim-with-analytics
-   ```
-   > If you are to try out an already released zip of this repo, please ignore this 2nd step also. 
-    Instead, extract the zip file and directly browse to `docker-apim-<released-version-here>docker-compose/apim-with-analytics` folder. 
+2. Switch to the `docker-compose/apim-is-as-km-with-analytics` folder.
+
+    ```
+    cd docker-apim/docker-compose/apim-is-as-km-with-analytics
+    ```
+    > If you are to try out an already released zip of this repo, please ignore this 2nd step also. 
+     Instead, extract the zip file and directly browse to `docker-apim-<released-version-here>docker-compose/apim-is-as-km-with-analytics` folder. 
      
-   > If you want to try out an already released tag, after executing 2nd step, checkout the relevant tag, 
-    i.e. for example: git checkout tags/v2.6.0.3 and continue below steps.
+    > If you want to try out an already released tag, after executing 2nd step, checkout the relevant tag, 
+     i.e. for example: git checkout tags/v2.6.0.3 and continue below steps.
 
 3. [Optional] If you are using WSO2 product Docker images with WSO2 updates, replace the WSO2 product Docker image names
    (relevant `image` attribute under each WSO2 product profile service) in the Docker Compose deployment definition.
     
   **Note**: By default, each product profile service is configured to use WSO2 product Docker images with GA releases.
 
-4. Execute following Docker Compose command to start the deployment.
-   ```
-   docker-compose up
-   ```
+4. Execute the `deploy.sh` script to start the deployment.
+     ```
+     ./deploy.sh
+     ```
 
 5. Access the WSO2 API Manager web UIs using the below URLs via a web browser.
 
-   ```
+ ```
    https://localhost:9443/publisher
    https://localhost:9443/store
    https://localhost:9443/admin
    https://localhost:9443/carbon
-   ```
-   Access the servers using following credentials.
-   
-   * Username: admin <br>
-   * Password: admin
+ ```
+ 
+ Access the servers using following credentials.
+    
+ * Username: admin <br>
+ * Password: admin
+ 
+ Please note that API Gateway will be available on following ports.
+ ```
+    https://localhost:8243
+    https://localhost:8280
+ ```
 
-   Please note that API Gateway will be available on following ports.
-   ```
-   https://localhost:8243
-   https://localhost:8280
-   ```
+ WSO2 API Manager will use WSO2 Identity Server to generate OAuth2 tokens and validate those tokens <br> during API invocations.

--- a/docker-compose/apim-is-as-km-with-analytics/scripts/deploy.sh
+++ b/docker-compose/apim-is-as-km-with-analytics/scripts/deploy.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# ------------------------------------------------------------------------
+# Copyright 2019 WSO2, Inc. (http://wso2.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+# ------------------------------------------------------------------------
+
+set -e
+
+ECHO=`which echo`
+GREP=`which grep`
+DOCKER_CLIENT=`which docker`
+DOCKER_COMPOSE_CLIENT=`which docker-compose`
+SED=`which sed`
+TEST=`which test`
+
+# methods
+function echoBold () {
+    ${ECHO} -e $'\e[1m'"${1}"$'\e[0m'
+}
+
+read -p "Do you have a WSO2 Subscription? (Y/N)" -n 1 -r
+${ECHO}
+
+if [[ ${REPLY} =~ ^[Yy]$ ]]; then
+    read -p "Enter Your WSO2 Username: " WSO2_SUBSCRIPTION_USERNAME
+    ${ECHO}
+    read -s -p "Enter Your WSO2 Password: " WSO2_SUBSCRIPTION_PASSWORD
+    ${ECHO}
+
+    echoBold "Logging into WSO2 Private Docker Registry (docker.wso2.com)"
+    ${DOCKER_CLIENT} login --username ${WSO2_SUBSCRIPTION_USERNAME} --password ${WSO2_SUBSCRIPTION_PASSWORD} docker.wso2.com
+
+    if ! ${SED} -i.bak -e 's|wso2/|docker.wso2.com/|' ../docker-compose.yml; then
+        echoBold "Could not configure to use the Docker image available at WSO2 Private Docker Registry (docker.wso2.com)"
+        exit 1
+    fi
+elif [[ ${REPLY} =~ ^[Nn]$ || -z "${REPLY}" ]]; then
+    if ! ${SED} -i.bak -e 's|docker.wso2.com/|wso2/|' ../docker-compose.yml; then
+        echoBold "Could not configure to use the WSO2 Docker image available at DockerHub"
+        exit 1
+    fi
+else
+    echoBold "You have entered an invalid option."
+    exit 1
+fi
+
+# remove backed up files
+${TEST} -f ../*.bak && rm ../*.bak
+
+cd ..
+
+${DOCKER_COMPOSE_CLIENT} up -d
+
+echoBold "
+To access the Management Console of WSO2 API Manager, use https://localhost:9443/carbon.
+To access the Publisher of WSO2 API Manager, use https://localhost:9443/publisher.
+To access the Store of WSO2 API Manager, use https://localhost:9443/store.
+
+To list the created WSO2 product server containers, use \`docker ps\` Docker client command.
+For instructions to delete the created WSO2 product server setup, please see the Docker Compose FAQ (https://wso2.com/products/install/faq/#iDocker)."

--- a/docker-compose/apim-with-analytics/docker-compose.yml
+++ b/docker-compose/apim-with-analytics/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       retries: 5
       start_period: 80s
   am-analytics:
-    image: docker.wso2.com/wso2am-analytics-worker:2.6.0
+    image: wso2/wso2am-analytics-worker:2.6.0
     ports:
       - "9091:9091"
       - "9444:9444"
@@ -32,7 +32,7 @@ services:
     volumes:
       - ./apim-analytics:/home/wso2carbon/wso2-config-volume
   api-manager:
-    image: docker.wso2.com/wso2am:2.6.0
+    image: wso2/wso2am:2.6.0
     healthcheck:
       test: ["CMD", "curl", "-k", "-f", "https://localhost:9443/carbon/admin/login.jsp"]
       interval: 10s

--- a/docker-compose/apim-with-analytics/scripts/README.md
+++ b/docker-compose/apim-with-analytics/scripts/README.md
@@ -38,10 +38,10 @@
     
   **Note**: By default, each product profile service is configured to use WSO2 product Docker images with GA releases.
 
-4. Execute following Docker Compose command to start the deployment.
-   ```
-   docker-compose up
-   ```
+4. Execute the `deploy.sh` script to start the deployment.
+     ```
+     ./deploy.sh
+     ```
 
 5. Access the WSO2 API Manager web UIs using the below URLs via a web browser.
 

--- a/docker-compose/apim-with-analytics/scripts/README.md
+++ b/docker-compose/apim-with-analytics/scripts/README.md
@@ -33,17 +33,12 @@
    > If you want to try out an already released tag, after executing 2nd step, checkout the relevant tag, 
     i.e. for example: git checkout tags/v2.6.0.3 and continue below steps.
 
-3. [Optional] If you are using WSO2 product Docker images with WSO2 updates, replace the WSO2 product Docker image names
-   (relevant `image` attribute under each WSO2 product profile service) in the Docker Compose deployment definition.
-    
-  **Note**: By default, each product profile service is configured to use WSO2 product Docker images with GA releases.
-
-4. Execute the `deploy.sh` script to start the deployment.
+3. Execute the `deploy.sh` script to start the deployment.
      ```
      ./deploy.sh
      ```
 
-5. Access the WSO2 API Manager web UIs using the below URLs via a web browser.
+4. Access the WSO2 API Manager web UIs using the below URLs via a web browser.
 
    ```
    https://localhost:9443/publisher

--- a/docker-compose/apim-with-analytics/scripts/deploy.sh
+++ b/docker-compose/apim-with-analytics/scripts/deploy.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# ------------------------------------------------------------------------
+# Copyright 2019 WSO2, Inc. (http://wso2.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+# ------------------------------------------------------------------------
+
+set -e
+
+ECHO=`which echo`
+GREP=`which grep`
+DOCKER_CLIENT=`which docker`
+DOCKER_COMPOSE_CLIENT=`which docker-compose`
+SED=`which sed`
+TEST=`which test`
+
+# methods
+function echoBold () {
+    ${ECHO} -e $'\e[1m'"${1}"$'\e[0m'
+}
+
+read -p "Do you have a WSO2 Subscription? (Y/N)" -n 1 -r
+${ECHO}
+
+if [[ ${REPLY} =~ ^[Yy]$ ]]; then
+    read -p "Enter Your WSO2 Username: " WSO2_SUBSCRIPTION_USERNAME
+    ${ECHO}
+    read -s -p "Enter Your WSO2 Password: " WSO2_SUBSCRIPTION_PASSWORD
+    ${ECHO}
+
+    echoBold "Logging into WSO2 Private Docker Registry (docker.wso2.com)"
+    ${DOCKER_CLIENT} login --username ${WSO2_SUBSCRIPTION_USERNAME} --password ${WSO2_SUBSCRIPTION_PASSWORD} docker.wso2.com
+
+    if ! ${SED} -i.bak -e 's|wso2/|docker.wso2.com/|' ../docker-compose.yml; then
+        echoBold "Could not configure to use the Docker image available at WSO2 Private Docker Registry (docker.wso2.com)"
+        exit 1
+    fi
+elif [[ ${REPLY} =~ ^[Nn]$ || -z "${REPLY}" ]]; then
+    if ! ${SED} -i.bak -e 's|docker.wso2.com/|wso2/|' ../docker-compose.yml; then
+        echoBold "Could not configure to use the WSO2 Docker image available at DockerHub"
+        exit 1
+    fi
+else
+    echoBold "You have entered an invalid option."
+    exit 1
+fi
+
+# remove backed up files
+${TEST} -f ../*.bak && rm ../*.bak
+
+cd ..
+
+${DOCKER_COMPOSE_CLIENT} up -d
+
+echoBold "
+To access the Management Console of WSO2 API Manager, use https://localhost:9443/carbon.
+To access the Publisher of WSO2 API Manager, use https://localhost:9443/publisher.
+To access the Store of WSO2 API Manager, use https://localhost:9443/store.
+
+To list the created WSO2 product server containers, use \`docker ps\` Docker client command.
+For instructions to delete the created WSO2 product server setup, please see the Docker Compose FAQ (https://wso2.com/products/install/faq/#iDocker)."

--- a/dockerfiles/alpine/apim-analytics/base/Dockerfile
+++ b/dockerfiles/alpine/apim-analytics/base/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Alpine Docker image
-FROM adoptopenjdk/openjdk8:jdk8u192-b12-alpine
+FROM adoptopenjdk/openjdk8:jdk8u212-b03-alpine
 MAINTAINER WSO2 Docker Maintainers "dev@wso2.org”
 
 # set user configurations

--- a/dockerfiles/alpine/apim/Dockerfile
+++ b/dockerfiles/alpine/apim/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Alpine Docker image
-FROM adoptopenjdk/openjdk8:jdk8u192-b12-alpine
+FROM adoptopenjdk/openjdk8:jdk8u212-b03-alpine
 MAINTAINER WSO2 Docker Maintainers "dev@wso2.org”
 
 # set user configurations

--- a/dockerfiles/alpine/is-as-km/Dockerfile
+++ b/dockerfiles/alpine/is-as-km/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Alpine Docker image
-FROM adoptopenjdk/openjdk8:jdk8u192-b12-alpine
+FROM adoptopenjdk/openjdk8:jdk8u212-b03-alpine
 MAINTAINER WSO2 Docker Maintainers "dev@wso2.org”
 
 # set user configurations

--- a/dockerfiles/ubuntu/apim-analytics/base/Dockerfile
+++ b/dockerfiles/ubuntu/apim-analytics/base/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
-FROM adoptopenjdk/openjdk8:jdk8u192-b12
+FROM adoptopenjdk/openjdk8:jdk8u212-b03
 MAINTAINER WSO2 Docker Maintainers "dev@wso2.org"
 
 # set user configurations

--- a/dockerfiles/ubuntu/apim/Dockerfile
+++ b/dockerfiles/ubuntu/apim/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
-FROM adoptopenjdk/openjdk8:jdk8u192-b12
+FROM adoptopenjdk/openjdk8:jdk8u212-b03
 MAINTAINER WSO2 Docker Maintainers "dev@wso2.org"
 
 # set user configurations

--- a/dockerfiles/ubuntu/is-as-km/Dockerfile
+++ b/dockerfiles/ubuntu/is-as-km/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
-FROM adoptopenjdk/openjdk8:jdk8u192-b12
+FROM adoptopenjdk/openjdk8:jdk8u212-b03
 MAINTAINER WSO2 Docker Maintainers "dev@wso2.org"
 
 # set user configurations


### PR DESCRIPTION
## Purpose
> Integrate support in Docker Compose resources for usage of both types of users: users with and without WSO2 subscriptions. Currently, only users with WSO2 subscriptions can utilize Docker Compose resources. This fixes https://github.com/wso2/docker-apim/issues/197. This PR also upgrades the AdoptOpenJDK version used in Docker resources with the latest version - `jdk8u212-b03`. Hence, it fixes https://github.com/wso2/docker-apim/issues/196.

## Goals
> Integrate support in Docker Compose resources for users with and without WSO2 subscriptions