### PR TITLE
Install libxml2-utils package in Alpine and Ubuntu based Docker resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Docker Compose files have been created according to the most common API Manager 
 product features along side their co-operate API management requirements. The Compose files make use of
 Docker images of WSO2 API Manager, WSO2 API Manager Analytics, WSO2 API Manager Identity Server as Key Manager and MySQL.
 
-**Change log** from previous v2.6.0.3 release: [View Here](CHANGELOG.md)
+**Change log** from previous v2.6.0.4 release: [View Here](CHANGELOG.md)
 
 ## Reporting issues
 

--- a/dockerfiles/alpine/apim/Dockerfile
+++ b/dockerfiles/alpine/apim/Dockerfile
@@ -61,7 +61,10 @@ RUN \
 # copy init script to user home
 COPY --chown=wso2carbon:wso2 docker-entrypoint.sh ${USER_HOME}/
 # install required packages
-RUN apk add --no-cache netcat-openbsd
+RUN \
+    apk add --no-cache \
+        libxml2-utils \
+        netcat-openbsd
 # add the WSO2 product distribution to user's home directory
 RUN \
     wget --no-check-certificate -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \

--- a/dockerfiles/ubuntu/apim/Dockerfile
+++ b/dockerfiles/ubuntu/apim/Dockerfile
@@ -63,6 +63,7 @@ COPY --chown=wso2carbon:wso2 docker-entrypoint.sh ${USER_HOME}/
 RUN \
     apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        libxml2-utils \
         netcat \
         unzip \
         wget \


### PR DESCRIPTION
## Purpose
> Install libxml2-utils package required by API Manager profile startup script in Alpine and Ubuntu based Docker resources. This fixes https://github.com/wso2/docker-apim/issues/183.

## Goals
> Install libxml2-utils package in Alpine and Ubuntu based Docker resources