### PR TITLE
Create Docker resources for WSO2 API Management profiles v3.0.0

### DIFF
--- a/.metadata
+++ b/.metadata
@@ -1,0 +1,199 @@
+# Copyright 2019 WSO2, Inc. (http://wso2.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+# ----------------------------------------------------------------------
+
+---
+#command line arguments
+params:
+   existing_version_wso2am: 2.6.0
+   new_version_wso2am: 3.0.0
+   existing_version_wso2am_analytics: 2.6.0
+   new_version_wso2am_analytics: 3.0.0
+   existing_version_wso2is: 5.7.0
+   new_version_wso2is: 5.9.0
+
+# files based configurations
+files:
+    # dockerfiles
+    # centos
+    - file_path: "dockerfiles/centos/apim/README.md"
+      relative_path: ~
+      file_type: "txt"
+      configurations:
+        - operation: replace
+          current_value: "{$arg.existing_version_wso2am}"
+          new_value: "{$arg.new_version_wso2am}"
+    - file_path: "dockerfiles/centos/apim/Dockerfile"
+      relative_path: ~
+      file_type: "txt"
+      configurations:
+        - operation: replace
+          current_value: "{$arg.existing_version_wso2am}"
+          new_value: "{$arg.new_version_wso2am}"
+    - file_path: "dockerfiles/centos/apim-analytics/worker/Dockerfile"
+      relative_path: ~
+      file_type: "txt"
+      configurations:
+        - operation: replace
+          current_value: "{$arg.existing_version_wso2am_analytics}"
+          new_value: "{$arg.new_version_wso2am_analytics}"
+    - file_path: "dockerfiles/centos/apim-analytics/worker/README.md"
+      relative_path: ~
+      file_type: "txt"
+      configurations:
+        - operation: replace
+          current_value: "{$arg.existing_version_wso2am_analytics}"
+          new_value: "{$arg.new_version_wso2am_analytics}"
+    - file_path: "dockerfiles/centos/apim-analytics/dashboard/Dockerfile"
+      relative_path: ~
+      file_type: "txt"
+      configurations:
+        - operation: replace
+          current_value: "{$arg.existing_version_wso2am_analytics}"
+          new_value: "{$arg.new_version_wso2am_analytics}"
+    - file_path: "dockerfiles/centos/apim-analytics/dashboard/README.md"
+      relative_path: ~
+      file_type: "txt"
+      configurations:
+        - operation: replace
+          current_value: "{$arg.existing_version_wso2am_analytics}"
+          new_value: "{$arg.new_version_wso2am_analytics}"
+    - file_path: "dockerfiles/centos/is-as-km/Dockerfile"
+      relative_path: ~
+      file_type: "txt"
+      configurations:
+        - operation: replace
+          current_value: "{$arg.existing_version_wso2is}"
+          new_value: "{$arg.new_version_wso2is}"
+    - file_path: "dockerfiles/centos/is-as-km/README.md"
+      relative_path: ~
+      file_type: "txt"
+      configurations:
+        - operation: replace
+          current_value: "{$arg.existing_version_wso2is}"
+          new_value: "{$arg.new_version_wso2is}"
+    # alpine
+    - file_path: "dockerfiles/alpine/apim/README.md"
+      relative_path: ~
+      file_type: "txt"
+      configurations:
+        - operation: replace
+          current_value: "{$arg.existing_version_wso2am}"
+          new_value: "{$arg.new_version_wso2am}"
+    - file_path: "dockerfiles/alpine/apim/Dockerfile"
+      relative_path: ~
+      file_type: "txt"
+      configurations:
+        - operation: replace
+          current_value: "{$arg.existing_version_wso2am}"
+          new_value: "{$arg.new_version_wso2am}"
+    - file_path: "dockerfiles/alpine/apim-analytics/worker/Dockerfile"
+      relative_path: ~
+      file_type: "txt"
+      configurations:
+        - operation: replace
+          current_value: "{$arg.existing_version_wso2am_analytics}"
+          new_value: "{$arg.new_version_wso2am_analytics}"
+    - file_path: "dockerfiles/alpine/apim-analytics/worker/README.md"
+      relative_path: ~
+      file_type: "txt"
+      configurations:
+        - operation: replace
+          current_value: "{$arg.existing_version_wso2am_analytics}"
+          new_value: "{$arg.new_version_wso2am_analytics}"
+    - file_path: "dockerfiles/alpine/apim-analytics/dashboard/Dockerfile"
+      relative_path: ~
+      file_type: "txt"
+      configurations:
+        - operation: replace
+          current_value: "{$arg.existing_version_wso2am_analytics}"
+          new_value: "{$arg.new_version_wso2am_analytics}"
+    - file_path: "dockerfiles/alpine/apim-analytics/dashboard/README.md"
+      relative_path: ~
+      file_type: "txt"
+      configurations:
+        - operation: replace
+          current_value: "{$arg.existing_version_wso2am_analytics}"
+          new_value: "{$arg.new_version_wso2am_analytics}"
+    - file_path: "dockerfiles/alpine/is-as-km/Dockerfile"
+      relative_path: ~
+      file_type: "txt"
+      configurations:
+        - operation: replace
+          current_value: "{$arg.existing_version_wso2is}"
+          new_value: "{$arg.new_version_wso2is}"
+    - file_path: "dockerfiles/alpine/is-as-km/README.md"
+      relative_path: ~
+      file_type: "txt"
+      configurations:
+        - operation: replace
+          current_value: "{$arg.existing_version_wso2is}"
+          new_value: "{$arg.new_version_wso2is}"
+    # ubuntu
+    - file_path: "dockerfiles/ubuntu/apim/README.md"
+      relative_path: ~
+      file_type: "txt"
+      configurations:
+        - operation: replace
+          current_value: "{$arg.existing_version_wso2am}"
+          new_value: "{$arg.new_version_wso2am}"
+    - file_path: "dockerfiles/ubuntu/apim/Dockerfile"
+      relative_path: ~
+      file_type: "txt"
+      configurations:
+        - operation: replace
+          current_value: "{$arg.existing_version_wso2am}"
+          new_value: "{$arg.new_version_wso2am}"
+    - file_path: "dockerfiles/ubuntu/apim-analytics/worker/Dockerfile"
+      relative_path: ~
+      file_type: "txt"
+      configurations:
+        - operation: replace
+          current_value: "{$arg.existing_version_wso2am_analytics}"
+          new_value: "{$arg.new_version_wso2am_analytics}"
+    - file_path: "dockerfiles/ubuntu/apim-analytics/worker/README.md"
+      relative_path: ~
+      file_type: "txt"
+      configurations:
+        - operation: replace
+          current_value: "{$arg.existing_version_wso2am_analytics}"
+          new_value: "{$arg.new_version_wso2am_analytics}"
+    - file_path: "dockerfiles/ubuntu/apim-analytics/dashboard/Dockerfile"
+      relative_path: ~
+      file_type: "txt"
+      configurations:
+        - operation: replace
+          current_value: "{$arg.existing_version_wso2am_analytics}"
+          new_value: "{$arg.new_version_wso2am_analytics}"
+    - file_path: "dockerfiles/ubuntu/apim-analytics/dashboard/README.md"
+      relative_path: ~
+      file_type: "txt"
+      configurations:
+        - operation: replace
+          current_value: "{$arg.existing_version_wso2am_analytics}"
+          new_value: "{$arg.new_version_wso2am_analytics}"
+    - file_path: "dockerfiles/ubuntu/is-as-km/Dockerfile"
+      relative_path: ~
+      file_type: "txt"
+      configurations:
+        - operation: replace
+          current_value: "{$arg.existing_version_wso2is}"
+          new_value: "{$arg.new_version_wso2is}"
+    - file_path: "dockerfiles/ubuntu/is-as-km/README.md"
+      relative_path: ~
+      file_type: "txt"
+      configurations:
+        - operation: replace
+          current_value: "{$arg.existing_version_wso2is}"
+          new_value: "{$arg.new_version_wso2is}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,68 +3,11 @@ All notable changes to this project 2.6.x per each release will be documented in
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
-## [v2.6.0.7] - 2019-08-28
-
-### Changed
-- Use AdoptOpenJDK version `jdk8u222-b10` in Alpine, CentOS, Ubuntu based Docker resources
-
-## [v2.6.0.6] - 2018-08-28
+## [v3.0.0.1] - TBA
 
 ### Added
-- Introduce support for artifact synchronization between API Manager nodes
-- Add `libxml2-utils` Debian package for executing the `<PRODUCT_HOME>/bin/profileSetup.sh` script in
-  Alpine and Ubuntu based WSO2 API Manager Docker resources.
-- Package the Kubernetes Membership Scheme in WSO2 Identity Server as KM Docker images.
+- WSO2 API Manager v3.0.x Docker resources for Alpine, CentOS and Ubuntu
+- WSO2 API Manager Analytics v3.0.x Docker resources for Alpine, CentOS and Ubuntu
+- WSO2 API Manager Identity Server as Key Manager v5.9.x Docker resources for Alpine, CentOS and Ubuntu
 
-### Changed
-- Use WSO2 product pack downloadable links to binaries available at JFrog Bintray.
-
-For detailed information on the tasks carried out during this release, please see the GitHub milestone
-[v2.6.0.6](https://github.com/wso2/docker-apim/milestone/5).
-
-## [v2.6.0.5] - 2019-06-07
-
-### Changed
-- Remove WSO2 API Manager Analytics base image
-
-## [v2.6.0.4] - 2019-06-06
-
-### Added
-- Add downloadable links for obtaining dependencies required to be available in Docker image build context
-- Use Dockerfile LABEL construct for defining the maintainer
-
-### Changed
-- Fix incorrect MOTDs
-- Remove temporarily persisted, default content of persistent runtime artifact folders
-- Prevent prepackaging additional artifacts required for Kubernetes Membership Scheme
-- Avoid creating Java Prefs directories in WSO2 API Manager Analytics v2.6.x Docker resources
-- Fix issue with container startup failure when Docker image indirect mount points are empty
-
-For detailed information on the tasks carried out during this release, please see the GitHub milestone
-[v2.6.0.4](https://github.com/wso2/docker-apim/milestone/4).
-
-## [v2.6.0.3] - 2019-05-25
-
-### Added
-- Integrate support in Docker Compose resources for users with and without WSO2 subscriptions
-
-### Changed
-- Use AdoptOpenJDK version `jdk8u212-b03` in Alpine, CentOS, Ubuntu based Docker resources
-
-## [v2.6.0.2] - 2018-01-11
-
-### Added
-- Integrate support for passing arguments during WSO2 server startup
-
-### Changed
-- Use AdoptOpenJDK version `jdk8u192-b12` in Alpine, CentOS, Ubuntu based Docker resources
-
-## [v2.6.0.1] - 2018-10-09
-
-### Added
-- WSO2 API Manager v2.6.x Docker resources for Alpine, CentOS and Ubuntu
-- WSO2 API Manager Analytics v2.6.x Docker resources for Alpine, CentOS and Ubuntu
-- WSO2 API Manager Identity Server as Key Manager v5.7.x Docker resources for Alpine, CentOS and Ubuntu
-- Docker Compose resources for WSO2 API Management
-
-[v2.6.0.7]: https://github.com/wso2/docker-apim/compare/v2.6.0.6...v2.6.0.7
+[v3.0.0.1]: https://github.com/wso2/docker-apim/compare/v2.6.0.7...v3.0.0.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,3 @@
-
 # Contributing to docker-apim
 
 Docker and Docker Compose resources for WSO2 API Management platform are open source and we encourage contributions from our community.
@@ -24,13 +23,13 @@ The issues page on GitHub is for tracking bugs and feature requests. When posing
 
 If you like to contribute with a bug fix or a new feature, start by posting an issue and discussing the best way to implement it.
 
-Unlike most projects, development for this repository is carried out on the `2.6.x` branch. This is because the `master` branch contains the latest stable release of the project.
-The code in `2.6.x` is merged to the `master` branch after a final review and a round of testing.
+Unlike most projects, development for this repository is carried out on the `3.0.x` branch. This is because the `master` branch contains the latest stable release of the project.
+The code in `3.0.x` is merged to the `master` branch after a final review and a round of testing.
 
 Please follow these guidelines when contributing to the code:
 
 1. Fork the current repository.
-2. Create a topic branch from the `2.6.x` branch.
+2. Create a topic branch from the `3.0.x` branch.
 3. Make commits in logical units.
 4. Before you send out the pull request, sync your forked repository with a remote repository. This makes your pull request simple and clear.
 
@@ -38,7 +37,7 @@ Please follow these guidelines when contributing to the code:
 git clone https://github.com/<user>/docker-apim.git
 git remote add upstream https://github.com/wso2/docker-apim.git
 git fetch upstream
-git checkout -b <topic-branch> upstream/2.6.x
+git checkout -b <topic-branch> upstream/3.0.x
 
 # add some work
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Docker Compose files have been created according to the most common API Manager 
 product features along side their co-operate API management requirements. The Compose files make use of
 Docker images of WSO2 API Manager, WSO2 API Manager Analytics, WSO2 API Manager Identity Server as Key Manager and MySQL.
 
-**Change log** from previous v2.6.0.6 release: [View Here](CHANGELOG.md)
+**Change log** from previous v2.6.0.7 release: [View Here](CHANGELOG.md)
 
 ## Reporting issues
 

--- a/dockerfiles/alpine/apim-analytics/dashboard/Dockerfile
+++ b/dockerfiles/alpine/apim-analytics/dashboard/Dockerfile
@@ -29,12 +29,12 @@ ARG USER_GROUP_ID=802
 ARG USER_HOME=/home/${USER}
 # build arguments for WSO2 product installation
 ARG WSO2_SERVER_NAME=wso2am-analytics
-ARG WSO2_SERVER_VERSION=2.6.0
+ARG WSO2_SERVER_VERSION=3.0.0
 ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
 ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
 ARG WSO2_SERVER_DIST_URL=https://bintray.com/wso2/binaryGA/download_file?file_path=${WSO2_SERVER}.zip
 # build arguments for external artifacts
-ARG MYSQL_CONNECTOR_VERSION=5.1.47
+ARG MYSQL_CONNECTOR_VERSION=8.0.17
 # build argument for MOTD
 ARG MOTD='printf "\n\
  Welcome to WSO2 Docker Resources \n\

--- a/dockerfiles/alpine/apim-analytics/dashboard/README.md
+++ b/dockerfiles/alpine/apim-analytics/dashboard/README.md
@@ -1,7 +1,7 @@
 # Dockerfile for Dashboard Profile of WSO2 API Manager Analytics #
 
 This section defines the step-by-step instructions to build [Alpine](https://hub.docker.com/_/alpine/) Linux based Docker image for Dashboard profile of
-WSO2 API Manager Analytics 2.6.0.
+WSO2 API Manager Analytics 3.0.0.
 
 ## Prerequisites
 
@@ -22,13 +22,13 @@ git clone https://github.com/wso2/docker-apim.git
 
 - Navigate to `<ANALYTICS_DOCKERFILE_HOME>` directory. <br>
   Execute `docker build` command as shown below.
-    + `docker build -t wso2am-analytics-dashboard:2.6.0-alpine .`
+    + `docker build -t wso2am-analytics-dashboard:3.0.0-alpine .`
     
 > By default, the Docker image will prepackage the General Availability (GA) release version of the relevant WSO2 product.
     
 ##### 3. Running Docker images specific to each profile.
 
-- `docker run -p 9643:9643 wso2am-analytics-dashboard:2.6.0-alpine`
+- `docker run -p 9643:9643 wso2am-analytics-dashboard:3.0.0-alpine`
 > Here, only port 9643 has been mapped to a Docker host port.
 You may map other container service ports, which have been exposed to Docker host ports, as desired.
 
@@ -46,7 +46,7 @@ As an example, steps required to change the port offset using `deployment.yaml` 
 
 ##### 1. Stop the Identity Server Analytics container if it's already running.
 
-In WSO2 API Manager Analytics 2.6.0 product distribution, `deployment.yaml` configuration file <br>
+In WSO2 API Manager Analytics 3.0.0 product distribution, `deployment.yaml` configuration file <br>
 can be found at `<DISTRIBUTION_HOME>/conf/worker`. Copy the file to some suitable location of the host machine, <br>
 referred to as `<SOURCE_CONFIGS>/deployment.yaml` and change the offset value under ports to 2.
 
@@ -62,10 +62,10 @@ chmod o+r <SOURCE_CONFIGS>/deployment.yaml
 docker run 
 -p 7713:7713
 --volume <SOURCE_CONFIGS>/deployment.yaml:<TARGET_CONFIGS>/deployment.yaml
-wso2am-analytics-worker:2.6.0-alpine
+wso2am-analytics-worker:3.0.0-alpine
 ```
 
-> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2am-analytics-2.6.0/conf/worker folder of the container.
+> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2am-analytics-3.0.0/conf/worker folder of the container.
 
 ## Docker command usage references
 

--- a/dockerfiles/alpine/apim-analytics/worker/Dockerfile
+++ b/dockerfiles/alpine/apim-analytics/worker/Dockerfile
@@ -29,12 +29,12 @@ ARG USER_GROUP_ID=802
 ARG USER_HOME=/home/${USER}
 # build arguments for WSO2 product installation
 ARG WSO2_SERVER_NAME=wso2am-analytics
-ARG WSO2_SERVER_VERSION=2.6.0
+ARG WSO2_SERVER_VERSION=3.0.0
 ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
 ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
 ARG WSO2_SERVER_DIST_URL=https://bintray.com/wso2/binaryGA/download_file?file_path=${WSO2_SERVER}.zip
 # build arguments for external artifacts
-ARG MYSQL_CONNECTOR_VERSION=5.1.47
+ARG MYSQL_CONNECTOR_VERSION=8.0.17
 # build argument for MOTD
 ARG MOTD='printf "\n\
  Welcome to WSO2 Docker Resources \n\

--- a/dockerfiles/alpine/apim-analytics/worker/README.md
+++ b/dockerfiles/alpine/apim-analytics/worker/README.md
@@ -1,7 +1,7 @@
 # Dockerfile for Worker Profile of WSO2 API Manager Analytics #
 
 This section defines the step-by-step instructions to build [Alpine](https://hub.docker.com/_/alpine/) Linux based Docker image for Worker profile of
-WSO2 API Manager Analytics 2.6.0.
+WSO2 API Manager Analytics 3.0.0.
 
 ## Prerequisites
 
@@ -22,13 +22,13 @@ git clone https://github.com/wso2/docker-apim.git
 
 - Navigate to `<ANALYTICS_DOCKERFILE_HOME>` directory. <br>
   Execute `docker build` command as shown below.
-    + `docker build -t wso2am-analytics-worker:2.6.0-alpine .`
+    + `docker build -t wso2am-analytics-worker:3.0.0-alpine .`
     
 > By default, the Docker image will prepackage the General Availability (GA) release version of the relevant WSO2 product.
     
 ##### 3. Running Docker images specific to each profile.
 
-- `docker run -p 9091:9091 wso2am-analytics-worker:2.6.0-alpine`
+- `docker run -p 9091:9091 wso2am-analytics-worker:3.0.0-alpine`
 > Here, only port 9091 has been mapped to a Docker host port.
 You may map other container service ports, which have been exposed to Docker host ports, as desired.
 
@@ -39,7 +39,7 @@ As an example, steps required to change the port offset using `deployment.yaml` 
 
 ##### 1. Stop the Identity Server Analytics container if it's already running.
 
-In WSO2 API Manager Analytics 2.6.0 product distribution, `deployment.yaml` configuration file <br>
+In WSO2 API Manager Analytics 3.0.0 product distribution, `deployment.yaml` configuration file <br>
 can be found at `<DISTRIBUTION_HOME>/conf/worker`. Copy the file to some suitable location of the host machine, <br>
 referred to as `<SOURCE_CONFIGS>/deployment.yaml` and change the offset value under ports to 2.
 
@@ -55,10 +55,10 @@ chmod o+r <SOURCE_CONFIGS>/deployment.yaml
 docker run 
 -p 7713:7713
 --volume <SOURCE_CONFIGS>/deployment.yaml:<TARGET_CONFIGS>/deployment.yaml
-wso2am-analytics-worker:2.6.0-alpine
+wso2am-analytics-worker:3.0.0-alpine
 ```
 
-> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2am-analytics-2.6.0/conf/worker folder of the container.
+> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2am-analytics-3.0.0/conf/worker folder of the container.
 
 ## Docker command usage references
 

--- a/dockerfiles/alpine/apim/Dockerfile
+++ b/dockerfiles/alpine/apim/Dockerfile
@@ -29,12 +29,12 @@ ARG USER_GROUP_ID=802
 ARG USER_HOME=/home/${USER}
 # build arguments for WSO2 product installation
 ARG WSO2_SERVER_NAME=wso2am
-ARG WSO2_SERVER_VERSION=2.6.0
+ARG WSO2_SERVER_VERSION=3.0.0
 ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
 ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
 ARG WSO2_SERVER_DIST_URL=https://bintray.com/wso2/binaryGA/download_file?file_path=${WSO2_SERVER}.zip
 # build arguments for external artifacts
-ARG MYSQL_CONNECTOR_VERSION=5.1.47
+ARG MYSQL_CONNECTOR_VERSION=8.0.17
 # build argument for MOTD
 ARG MOTD='printf "\n\
  Welcome to WSO2 Docker Resources \n\
@@ -49,14 +49,6 @@ RUN \
     addgroup -S -g ${USER_GROUP_ID} ${USER_GROUP} \
     && adduser -S -u ${USER_ID} -h ${USER_HOME} -G ${USER_GROUP} ${USER} \
     && echo ${MOTD} > "${ENV}"
-
-# create Java prefs dir
-# this is to avoid warning logs printed by FileSystemPreferences class
-RUN \
-    mkdir -p ${USER_HOME}/.java/.systemPrefs \
-    && mkdir -p ${USER_HOME}/.java/.userPrefs \
-    && chmod -R 755 ${USER_HOME}/.java \
-    && chown -R ${USER}:${USER_GROUP} ${USER_HOME}/.java
 
 # copy init script to user home
 COPY --chown=wso2carbon:wso2 docker-entrypoint.sh ${USER_HOME}/
@@ -82,8 +74,7 @@ USER ${USER_ID}
 WORKDIR ${USER_HOME}
 
 # set environment variables
-ENV JAVA_OPTS="-Djava.util.prefs.systemRoot=${USER_HOME}/.java -Djava.util.prefs.userRoot=${USER_HOME}/.java/.userPrefs" \
-    WORKING_DIRECTORY=${USER_HOME} \
+ENV WORKING_DIRECTORY=${USER_HOME} \
     WSO2_SERVER_HOME=${WSO2_SERVER_HOME}
 
 # expose ports

--- a/dockerfiles/alpine/apim/README.md
+++ b/dockerfiles/alpine/apim/README.md
@@ -1,6 +1,6 @@
 # Dockerfile for WSO2 API Manager #
 
-This section defines the step-by-step instructions to build an [Alpine](https://hub.docker.com/_/alpine/) Linux based Docker image for WSO2 API Manager 2.6.0.
+This section defines the step-by-step instructions to build an [Alpine](https://hub.docker.com/_/alpine/) Linux based Docker image for WSO2 API Manager 3.0.0.
 
 ## Prerequisites
 
@@ -21,13 +21,13 @@ git clone https://github.com/wso2/docker-apim.git
 
 - Navigate to `<AM_DOCKERFILE_HOME>` directory. <br>
   Execute `docker build` command as shown below.
-    + `docker build -t wso2am:2.6.0-alpine .`
+    + `docker build -t wso2am:3.0.0-alpine .`
 
 > By default, the Docker image will prepackage the General Availability (GA) release version of the relevant WSO2 product.
 
 ##### 3. Running the Docker image.
 
-- `docker run -it -p 9443:9443 wso2am:2.6.0-alpine`
+- `docker run -it -p 9443:9443 wso2am:3.0.0-alpine`
 > Here, only port 9443 (HTTPS servlet transport) has been mapped to a Docker host port.
 You may map other container service ports, which have been exposed to Docker host ports, as desired.
 
@@ -41,18 +41,18 @@ You may map other container service ports, which have been exposed to Docker hos
 ## How to update configurations
 
 Configurations would lie on the Docker host machine and they can be volume mounted to the container. <br>
-As an example, steps required to change the port offset using `carbon.xml` is as follows:
+As an example, steps required to change the port offset using `deployment.toml` is as follows:
 
 ##### 1. Stop the API Manager container if it's already running.
 
-In WSO2 API Manager 2.6.0 product distribution, `carbon.xml` configuration file <br>
+In WSO2 API Manager 3.0.0 product distribution, `deployment.toml` configuration file <br>
 can be found at `<DISTRIBUTION_HOME>/repository/conf`. Copy the file to some suitable location of the host machine, <br>
-referred to as `<SOURCE_CONFIGS>/carbon.xml` and change the offset value under ports to 1.
+referred to as `<SOURCE_CONFIGS>/deployment.toml` and change the offset value (`[server]->offset`) to 1.
 
-##### 2. Grant read permission to `other` users for `<SOURCE_CONFIGS>/carbon.xml`.
+##### 2. Grant read permission to `other` users for `<SOURCE_CONFIGS>/deployment.toml`.
 
 ```
-chmod o+r <SOURCE_CONFIGS>/carbon.xml
+chmod o+r <SOURCE_CONFIGS>/deployment.toml
 ```
 
 ##### 3. Run the image by mounting the file to container as follows:
@@ -60,11 +60,11 @@ chmod o+r <SOURCE_CONFIGS>/carbon.xml
 ```
 docker run \
 -p 9444:9444 \
---volume <SOURCE_CONFIGS>/carbon.xml:<TARGET_CONFIGS>/carbon.xml \
-wso2am:2.6.0-alpine
+--volume <SOURCE_CONFIGS>/deployment.toml:<TARGET_CONFIGS>/deployment.toml \
+wso2am:3.0.0-alpine
 ```
 
-> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2am-2.6.0/repository/conf folder of the container.
+> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2am-3.0.0/repository/conf folder of the container.
 
 ## Docker command usage references
 

--- a/dockerfiles/alpine/is-as-km/Dockerfile
+++ b/dockerfiles/alpine/is-as-km/Dockerfile
@@ -29,14 +29,14 @@ ARG USER_GROUP_ID=802
 ARG USER_HOME=/home/${USER}
 # build arguments for WSO2 product installation
 ARG WSO2_SERVER_NAME=wso2is-km
-ARG WSO2_SERVER_VERSION=5.7.0
+ARG WSO2_SERVER_VERSION=5.9.0
 ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
 ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
 ARG WSO2_SERVER_DIST_URL=https://bintray.com/wso2/binaryGA/download_file?file_path=${WSO2_SERVER}.zip
 # build arguments for external artifacts
 ARG DNS_JAVA_VERSION=2.1.8
 ARG K8S_MEMBERSHIP_SCHEME_VERSION=1.0.5
-ARG MYSQL_CONNECTOR_VERSION=5.1.47
+ARG MYSQL_CONNECTOR_VERSION=8.0.17
 # build argument for MOTD
 ARG MOTD='printf "\n\
  Welcome to WSO2 Docker Resources \n\
@@ -51,14 +51,6 @@ RUN \
     addgroup -S -g ${USER_GROUP_ID} ${USER_GROUP} \
     && adduser -S -u ${USER_ID} -h ${USER_HOME} -G ${USER_GROUP} ${USER} \
     && echo ${MOTD} > "${ENV}"
-
-# create Java prefs dir
-# this is to avoid warning logs printed by FileSystemPreferences class
-RUN \
-    mkdir -p ${USER_HOME}/.java/.systemPrefs \
-    && mkdir -p ${USER_HOME}/.java/.userPrefs \
-    && chmod -R 755 ${USER_HOME}/.java \
-    && chown -R ${USER}:${USER_GROUP} ${USER_HOME}/.java
 
 # copy init script to user home
 COPY --chown=wso2carbon:wso2 docker-entrypoint.sh ${USER_HOME}/
@@ -81,8 +73,7 @@ USER ${USER_ID}
 WORKDIR ${USER_HOME}
 
 # set environment variables
-ENV JAVA_OPTS="-Djava.util.prefs.systemRoot=${USER_HOME}/.java -Djava.util.prefs.userRoot=${USER_HOME}/.java/.userPrefs" \
-    WORKING_DIRECTORY=${USER_HOME} \
+ENV WORKING_DIRECTORY=${USER_HOME} \
     WSO2_SERVER_HOME=${WSO2_SERVER_HOME}
 
 # expose ports

--- a/dockerfiles/alpine/is-as-km/README.md
+++ b/dockerfiles/alpine/is-as-km/README.md
@@ -21,13 +21,13 @@ git clone https://github.com/wso2/docker-apim.git
 
 - Navigate to `<IS_KM_DOCKERFILE_HOME>` directory. <br>
   Execute `docker build` command as shown below.
-    + `docker build -t wso2is-km:5.7.0-alpine .`
+    + `docker build -t wso2is-km:5.9.0-alpine .`
 
 > By default, the Docker image will prepackage the General Availability (GA) release version of the relevant WSO2 product.
   
 ##### 3. Running the Docker image.
 
-- `docker run -it -p 9443:9443 wso2is-km:5.7.0-alpine`
+- `docker run -it -p 9443:9443 wso2is-km:5.9.0-alpine`
 
 ##### 4. Accessing management console.
 
@@ -39,18 +39,18 @@ git clone https://github.com/wso2/docker-apim.git
 ## How to update configurations
 
 Configurations would lie on the Docker host machine and they can be volume mounted to the container. <br>
-As an example, steps required to change the port offset using `carbon.xml` is as follows:
+As an example, steps required to change the port offset using `deployment.toml` is as follows:
 
 ##### 1. Stop the Identity Server as Key Manager container if it's already running.
 
-In WSO2 Identity Server as Key Manager 5.7.0 product distribution, `carbon.xml` configuration file <br>
+In WSO2 Identity Server as Key Manager 5.9.0 product distribution, `deployment.toml` configuration file <br>
 can be found at `<DISTRIBUTION_HOME>/repository/conf`. Copy the file to some suitable location of the host machine, <br>
-referred to as `<SOURCE_CONFIGS>/carbon.xml` and change the offset value under ports to 1.
+referred to as `<SOURCE_CONFIGS>/deployment.toml` and change the offset value (`[server]->offset`) to 1.
 
-##### 2. Grant read permission to `other` users for `<SOURCE_CONFIGS>/carbon.xml`.
+##### 2. Grant read permission to `other` users for `<SOURCE_CONFIGS>/deployment.toml`.
 
 ```
-chmod o+r <SOURCE_CONFIGS>/carbon.xml
+chmod o+r <SOURCE_CONFIGS>/deployment.toml
 ```
 
 ##### 3. Run the image by mounting the file to container as follows:
@@ -58,11 +58,11 @@ chmod o+r <SOURCE_CONFIGS>/carbon.xml
 ```
 docker run \
 -p 9444:9444 \
---volume <SOURCE_CONFIGS>/carbon.xml:<TARGET_CONFIGS>/carbon.xml \
-wso2is-km:5.7.0-alpine
+--volume <SOURCE_CONFIGS>/deployment.toml:<TARGET_CONFIGS>/deployment.toml \
+wso2is-km:5.9.0-alpine
 ```
 
-> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2is-km-5.7.0/repository/conf folder of the container.
+> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2is-km-5.9.0/repository/conf folder of the container.
 
 ## Docker command usage references
 

--- a/dockerfiles/centos/apim-analytics/dashboard/Dockerfile
+++ b/dockerfiles/centos/apim-analytics/dashboard/Dockerfile
@@ -31,12 +31,12 @@ ARG USER_HOME=/home/${USER}
 ARG JAVA_HOME=${USER_HOME}/java
 # build arguments for WSO2 product installation
 ARG WSO2_SERVER_NAME=wso2am-analytics
-ARG WSO2_SERVER_VERSION=2.6.0
+ARG WSO2_SERVER_VERSION=3.0.0
 ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
 ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
 ARG WSO2_SERVER_DIST_URL=https://bintray.com/wso2/binaryGA/download_file?file_path=${WSO2_SERVER}.zip
 # build arguments for external artifacts
-ARG MYSQL_CONNECTOR_VERSION=5.1.47
+ARG MYSQL_CONNECTOR_VERSION=8.0.17
 # build argument for MOTD
 ARG MOTD='printf "\n\
 Welcome to WSO2 Docker resources.\n\

--- a/dockerfiles/centos/apim-analytics/dashboard/README.md
+++ b/dockerfiles/centos/apim-analytics/dashboard/README.md
@@ -1,7 +1,7 @@
 # Dockerfile for Dashboard Profile of WSO2 API Manager Analytics #
 
 This section defines the step-by-step instructions to build [CentOS](https://hub.docker.com/_/centos/) Linux based Docker image for Dashboard profile of
-WSO2 API Manager Analytics 2.6.0.
+WSO2 API Manager Analytics 3.0.0.
 
 ## Prerequisites
 
@@ -22,13 +22,13 @@ git clone https://github.com/wso2/docker-apim.git
 
 - Navigate to `<ANALYTICS_DOCKERFILE_HOME>` directory. <br>
   Execute `docker build` command as shown below.
-    + `docker build -t wso2am-analytics-dashboard:2.6.0-centos .`
+    + `docker build -t wso2am-analytics-dashboard:3.0.0-centos .`
     
 > By default, the Docker image will prepackage the General Availability (GA) release version of the relevant WSO2 product.
     
 ##### 3. Running Docker images specific to each profile.
 
-- `docker run -p 9643:9643 wso2am-analytics-dashboard:2.6.0-centos`
+- `docker run -p 9643:9643 wso2am-analytics-dashboard:3.0.0-centos`
 > Here, only port 9643 has been mapped to a Docker host port.
 You may map other container service ports, which have been exposed to Docker host ports, as desired.
 
@@ -46,7 +46,7 @@ As an example, steps required to change the port offset using `deployment.yaml` 
 
 ##### 1. Stop the Identity Server Analytics container if it's already running.
 
-In WSO2 API Manager Analytics 2.6.0 product distribution, `deployment.yaml` configuration file <br>
+In WSO2 API Manager Analytics 3.0.0 product distribution, `deployment.yaml` configuration file <br>
 can be found at `<DISTRIBUTION_HOME>/conf/worker`. Copy the file to some suitable location of the host machine, <br>
 referred to as `<SOURCE_CONFIGS>/deployment.yaml` and change the offset value under ports to 2.
 
@@ -62,10 +62,10 @@ chmod o+r <SOURCE_CONFIGS>/deployment.yaml
 docker run 
 -p 7713:7713
 --volume <SOURCE_CONFIGS>/deployment.yaml:<TARGET_CONFIGS>/deployment.yaml
-wso2am-analytics-worker:2.6.0-centos
+wso2am-analytics-worker:3.0.0-centos
 ```
 
-> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2am-analytics-2.6.0/conf/worker folder of the container.
+> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2am-analytics-3.0.0/conf/worker folder of the container.
 
 ## Docker command usage references
 

--- a/dockerfiles/centos/apim-analytics/worker/Dockerfile
+++ b/dockerfiles/centos/apim-analytics/worker/Dockerfile
@@ -31,12 +31,12 @@ ARG USER_HOME=/home/${USER}
 ARG JAVA_HOME=${USER_HOME}/java
 # build arguments for WSO2 product installation
 ARG WSO2_SERVER_NAME=wso2am-analytics
-ARG WSO2_SERVER_VERSION=2.6.0
+ARG WSO2_SERVER_VERSION=3.0.0
 ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
 ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
 ARG WSO2_SERVER_DIST_URL=https://bintray.com/wso2/binaryGA/download_file?file_path=${WSO2_SERVER}.zip
 # build arguments for external artifacts
-ARG MYSQL_CONNECTOR_VERSION=5.1.47
+ARG MYSQL_CONNECTOR_VERSION=8.0.17
 # build argument for MOTD
 ARG MOTD='printf "\n\
 Welcome to WSO2 Docker resources.\n\

--- a/dockerfiles/centos/apim-analytics/worker/README.md
+++ b/dockerfiles/centos/apim-analytics/worker/README.md
@@ -1,7 +1,7 @@
 # Dockerfile for Worker Profile of WSO2 API Manager Analytics #
 
 This section defines the step-by-step instructions to build [CentOS](https://hub.docker.com/_/centos/) Linux based Docker image for Worker profile of
-WSO2 API Manager Analytics 2.6.0.
+WSO2 API Manager Analytics 3.0.0.
 
 ## Prerequisites
 
@@ -22,13 +22,13 @@ git clone https://github.com/wso2/docker-apim.git
 
 - Navigate to `<ANALYTICS_DOCKERFILE_HOME>` directory. <br>
   Execute `docker build` command as shown below.
-    + `docker build -t wso2am-analytics-worker:2.6.0-centos .`
+    + `docker build -t wso2am-analytics-worker:3.0.0-centos .`
     
 > By default, the Docker image will prepackage the General Availability (GA) release version of the relevant WSO2 product.
     
 ##### 3. Running Docker images specific to each profile.
 
-- `docker run -p 9091:9091 wso2am-analytics-worker:2.6.0-centos`
+- `docker run -p 9091:9091 wso2am-analytics-worker:3.0.0-centos`
 > Here, only port 9091 has been mapped to a Docker host port.
 You may map other container service ports, which have been exposed to Docker host ports, as desired.
 
@@ -39,7 +39,7 @@ As an example, steps required to change the port offset using `deployment.yaml` 
 
 ##### 1. Stop the Identity Server Analytics container if it's already running.
 
-In WSO2 API Manager Analytics 2.6.0 product distribution, `deployment.yaml` configuration file <br>
+In WSO2 API Manager Analytics 3.0.0 product distribution, `deployment.yaml` configuration file <br>
 can be found at `<DISTRIBUTION_HOME>/conf/worker`. Copy the file to some suitable location of the host machine, <br>
 referred to as `<SOURCE_CONFIGS>/deployment.yaml` and change the offset value under ports to 2.
 
@@ -55,10 +55,10 @@ chmod o+r <SOURCE_CONFIGS>/deployment.yaml
 docker run 
 -p 7713:7713
 --volume <SOURCE_CONFIGS>/deployment.yaml:<TARGET_CONFIGS>/deployment.yaml
-wso2am-analytics-worker:2.6.0-centos
+wso2am-analytics-worker:3.0.0-centos
 ```
 
-> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2am-analytics-2.6.0/conf/worker folder of the container.
+> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2am-analytics-3.0.0/conf/worker folder of the container.
 
 ## Docker command usage references
 

--- a/dockerfiles/centos/apim/Dockerfile
+++ b/dockerfiles/centos/apim/Dockerfile
@@ -31,12 +31,12 @@ ARG USER_HOME=/home/${USER}
 ARG JAVA_HOME=${USER_HOME}/java
 # build arguments for WSO2 product installation
 ARG WSO2_SERVER_NAME=wso2am
-ARG WSO2_SERVER_VERSION=2.6.0
+ARG WSO2_SERVER_VERSION=3.0.0
 ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
 ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
 ARG WSO2_SERVER_DIST_URL=https://bintray.com/wso2/binaryGA/download_file?file_path=${WSO2_SERVER}.zip
 # build arguments for external artifacts
-ARG MYSQL_CONNECTOR_VERSION=5.1.47
+ARG MYSQL_CONNECTOR_VERSION=8.0.17
 # build argument for MOTD
 ARG MOTD='printf "\n\
 Welcome to WSO2 Docker resources.\n\

--- a/dockerfiles/centos/apim/README.md
+++ b/dockerfiles/centos/apim/README.md
@@ -1,6 +1,6 @@
 # Dockerfile for WSO2 API Manager #
 
-This section defines the step-by-step instructions to build an [CentOS](https://hub.docker.com/_/centos/) Linux based Docker image for WSO2 API Manager 2.6.0.
+This section defines the step-by-step instructions to build an [CentOS](https://hub.docker.com/_/centos/) Linux based Docker image for WSO2 API Manager 3.0.0.
 
 ## Prerequisites
 
@@ -22,13 +22,13 @@ git clone https://github.com/wso2/docker-apim.git
 
 - Navigate to `<AM_DOCKERFILE_HOME>` directory. <br>
   Execute `docker build` command as shown below.
-    + `docker build -t wso2am:2.6.0-centos .`
+    + `docker build -t wso2am:3.0.0-centos .`
 
 > By default, the Docker image will prepackage the General Availability (GA) release version of the relevant WSO2 product.
 
 ##### 3. Running the Docker image.
 
-- `docker run -it -p 9443:9443 wso2am:2.6.0-centos`
+- `docker run -it -p 9443:9443 wso2am:3.0.0-centos`
 > Here, only port 9443 (HTTPS servlet transport) has been mapped to a Docker host port.
 You may map other container service ports, which have been exposed to Docker host ports, as desired.
 
@@ -42,18 +42,18 @@ You may map other container service ports, which have been exposed to Docker hos
 ## How to update configurations
 
 Configurations would lie on the Docker host machine and they can be volume mounted to the container. <br>
-As an example, steps required to change the port offset using `carbon.xml` is as follows:
+As an example, steps required to change the port offset using `deployment.toml` is as follows:
 
 ##### 1. Stop the API Manager container if it's already running.
 
-In WSO2 API Manager 2.6.0 product distribution, `carbon.xml` configuration file <br>
+In WSO2 API Manager 3.0.0 product distribution, `deployment.toml` configuration file <br>
 can be found at `<DISTRIBUTION_HOME>/repository/conf`. Copy the file to some suitable location of the host machine, <br>
-referred to as `<SOURCE_CONFIGS>/carbon.xml` and change the offset value under ports to 1.
+referred to as `<SOURCE_CONFIGS>/deployment.toml` and change the offset value (`[server]->offset`) to 1.
 
-##### 2. Grant read permission to `other` users for `<SOURCE_CONFIGS>/carbon.xml`.
+##### 2. Grant read permission to `other` users for `<SOURCE_CONFIGS>/deployment.toml`.
 
 ```
-chmod o+r <SOURCE_CONFIGS>/carbon.xml
+chmod o+r <SOURCE_CONFIGS>/deployment.toml
 ```
 
 ##### 3. Run the image by mounting the file to container as follows:
@@ -61,11 +61,11 @@ chmod o+r <SOURCE_CONFIGS>/carbon.xml
 ```
 docker run \
 -p 9444:9444 \
---volume <SOURCE_CONFIGS>/carbon.xml:<TARGET_CONFIGS>/carbon.xml \
-wso2am:2.6.0-centos
+--volume <SOURCE_CONFIGS>/deployment.toml:<TARGET_CONFIGS>/deployment.toml \
+wso2am:3.0.0-centos
 ```
 
-> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2am-2.6.0/repository/conf folder of the container.
+> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2am-3.0.0/repository/conf folder of the container.
 
 ## Docker command usage references
 

--- a/dockerfiles/centos/is-as-km/Dockerfile
+++ b/dockerfiles/centos/is-as-km/Dockerfile
@@ -31,14 +31,14 @@ ARG USER_HOME=/home/${USER}
 ARG JAVA_HOME=${USER_HOME}/java
 # build arguments for WSO2 product installation
 ARG WSO2_SERVER_NAME=wso2is-km
-ARG WSO2_SERVER_VERSION=5.7.0
+ARG WSO2_SERVER_VERSION=5.9.0
 ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
 ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
 ARG WSO2_SERVER_DIST_URL=https://bintray.com/wso2/binaryGA/download_file?file_path=${WSO2_SERVER}.zip
 # build arguments for external artifacts
 ARG DNS_JAVA_VERSION=2.1.8
 ARG K8S_MEMBERSHIP_SCHEME_VERSION=1.0.5
-ARG MYSQL_CONNECTOR_VERSION=5.1.47
+ARG MYSQL_CONNECTOR_VERSION=8.0.17
 # build argument for MOTD
 ARG MOTD='printf "\n\
 Welcome to WSO2 Docker resources.\n\

--- a/dockerfiles/centos/is-as-km/README.md
+++ b/dockerfiles/centos/is-as-km/README.md
@@ -21,13 +21,13 @@ git clone https://github.com/wso2/docker-apim.git
 
 - Navigate to `<IS_KM_DOCKERFILE_HOME>` directory. <br>
   Execute `docker build` command as shown below.
-    + `docker build -t wso2is-km:5.7.0-centos .`
+    + `docker build -t wso2is-km:5.9.0-centos .`
 
 > By default, the Docker image will prepackage the General Availability (GA) release version of the relevant WSO2 product.
   
 ##### 3. Running the Docker image.
 
-- `docker run -it -p 9443:9443 wso2is-km:5.7.0-centos`
+- `docker run -it -p 9443:9443 wso2is-km:5.9.0-centos`
 
 ##### 4. Accessing management console.
 
@@ -39,18 +39,18 @@ git clone https://github.com/wso2/docker-apim.git
 ## How to update configurations
 
 Configurations would lie on the Docker host machine and they can be volume mounted to the container. <br>
-As an example, steps required to change the port offset using `carbon.xml` is as follows:
+As an example, steps required to change the port offset using `deployment.toml` is as follows:
 
 ##### 1. Stop the Identity Server as Key Manager container if it's already running.
 
-In WSO2 Identity Server as Key Manager 5.7.0 product distribution, `carbon.xml` configuration file <br>
+In WSO2 Identity Server as Key Manager 5.9.0 product distribution, `deployment.toml` configuration file <br>
 can be found at `<DISTRIBUTION_HOME>/repository/conf`. Copy the file to some suitable location of the host machine, <br>
-referred to as `<SOURCE_CONFIGS>/carbon.xml` and change the offset value under ports to 1.
+referred to as `<SOURCE_CONFIGS>/deployment.toml` and change the offset value (`[server]->offset`) to 1.
 
-##### 2. Grant read permission to `other` users for `<SOURCE_CONFIGS>/carbon.xml`.
+##### 2. Grant read permission to `other` users for `<SOURCE_CONFIGS>/deployment.toml`.
 
 ```
-chmod o+r <SOURCE_CONFIGS>/carbon.xml
+chmod o+r <SOURCE_CONFIGS>/deployment.toml
 ```
 
 ##### 3. Run the image by mounting the file to container as follows:
@@ -58,11 +58,11 @@ chmod o+r <SOURCE_CONFIGS>/carbon.xml
 ```
 docker run \
 -p 9444:9444 \
---volume <SOURCE_CONFIGS>/carbon.xml:<TARGET_CONFIGS>/carbon.xml \
-wso2is-km:5.7.0-centos
+--volume <SOURCE_CONFIGS>/deployment.toml:<TARGET_CONFIGS>/deployment.toml \
+wso2is-km:5.9.0-centos
 ```
 
-> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2is-km-5.7.0/repository/conf folder of the container.
+> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2is-km-5.9.0/repository/conf folder of the container.
 
 ## Docker command usage references
 

--- a/dockerfiles/ubuntu/apim-analytics/dashboard/Dockerfile
+++ b/dockerfiles/ubuntu/apim-analytics/dashboard/Dockerfile
@@ -29,12 +29,12 @@ ARG USER_GROUP_ID=802
 ARG USER_HOME=/home/${USER}
 # build arguments for WSO2 product installation
 ARG WSO2_SERVER_NAME=wso2am-analytics
-ARG WSO2_SERVER_VERSION=2.6.0
+ARG WSO2_SERVER_VERSION=3.0.0
 ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
 ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
 ARG WSO2_SERVER_DIST_URL=https://bintray.com/wso2/binaryGA/download_file?file_path=${WSO2_SERVER}.zip
 # build arguments for external artifacts
-ARG MYSQL_CONNECTOR_VERSION=5.1.47
+ARG MYSQL_CONNECTOR_VERSION=8.0.17
 # build argument for MOTD
 ARG MOTD="\n\
 Welcome to WSO2 Docker resources.\n\

--- a/dockerfiles/ubuntu/apim-analytics/dashboard/README.md
+++ b/dockerfiles/ubuntu/apim-analytics/dashboard/README.md
@@ -1,7 +1,7 @@
 # Dockerfile for Dashboard Profile of WSO2 API Manager Analytics #
 
 This section defines the step-by-step instructions to build [Ubuntu](https://hub.docker.com/_/ubuntu/) Linux based Docker image for Dashboard profile of
-WSO2 API Manager Analytics 2.6.0.
+WSO2 API Manager Analytics 3.0.0.
 
 ## Prerequisites
 
@@ -22,13 +22,13 @@ git clone https://github.com/wso2/docker-apim.git
 
 - Navigate to `<ANALYTICS_DOCKERFILE_HOME>` directory. <br>
   Execute `docker build` command as shown below.
-    + `docker build -t wso2am-analytics-dashboard:2.6.0 .`
+    + `docker build -t wso2am-analytics-dashboard:3.0.0 .`
     
 > By default, the Docker image will prepackage the General Availability (GA) release version of the relevant WSO2 product.
     
 ##### 3. Running Docker images specific to each profile.
 
-- `docker run -p 9643:9643 wso2am-analytics-dashboard:2.6.0`
+- `docker run -p 9643:9643 wso2am-analytics-dashboard:3.0.0`
 > Here, only port 9643 has been mapped to a Docker host port.
 You may map other container service ports, which have been exposed to Docker host ports, as desired.
 
@@ -46,7 +46,7 @@ As an example, steps required to change the port offset using `deployment.yaml` 
 
 ##### 1. Stop the Identity Server Analytics container if it's already running.
 
-In WSO2 API Manager Analytics 2.6.0 product distribution, `deployment.yaml` configuration file <br>
+In WSO2 API Manager Analytics 3.0.0 product distribution, `deployment.yaml` configuration file <br>
 can be found at `<DISTRIBUTION_HOME>/conf/worker`. Copy the file to some suitable location of the host machine, <br>
 referred to as `<SOURCE_CONFIGS>/deployment.yaml` and change the offset value under ports to 2.
 
@@ -62,10 +62,10 @@ chmod o+r <SOURCE_CONFIGS>/deployment.yaml
 docker run 
 -p 7713:7713
 --volume <SOURCE_CONFIGS>/deployment.yaml:<TARGET_CONFIGS>/deployment.yaml
-wso2am-analytics-worker:2.6.0
+wso2am-analytics-worker:3.0.0
 ```
 
-> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2am-analytics-2.6.0/conf/worker folder of the container.
+> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2am-analytics-3.0.0/conf/worker folder of the container.
 
 ## Docker command usage references
 

--- a/dockerfiles/ubuntu/apim-analytics/worker/Dockerfile
+++ b/dockerfiles/ubuntu/apim-analytics/worker/Dockerfile
@@ -29,12 +29,12 @@ ARG USER_GROUP_ID=802
 ARG USER_HOME=/home/${USER}
 # build arguments for WSO2 product installation
 ARG WSO2_SERVER_NAME=wso2am-analytics
-ARG WSO2_SERVER_VERSION=2.6.0
+ARG WSO2_SERVER_VERSION=3.0.0
 ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
 ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
 ARG WSO2_SERVER_DIST_URL=https://bintray.com/wso2/binaryGA/download_file?file_path=${WSO2_SERVER}.zip
 # build arguments for external artifacts
-ARG MYSQL_CONNECTOR_VERSION=5.1.47
+ARG MYSQL_CONNECTOR_VERSION=8.0.17
 # build argument for MOTD
 ARG MOTD="\n\
 Welcome to WSO2 Docker resources.\n\

--- a/dockerfiles/ubuntu/apim-analytics/worker/README.md
+++ b/dockerfiles/ubuntu/apim-analytics/worker/README.md
@@ -1,7 +1,7 @@
 # Dockerfile for Worker Profile of WSO2 API Manager Analytics #
 
 This section defines the step-by-step instructions to build [Ubuntu](https://hub.docker.com/_/ubuntu/) Linux based Docker image for Worker profile of
-WSO2 API Manager Analytics 2.6.0.
+WSO2 API Manager Analytics 3.0.0.
 
 ## Prerequisites
 
@@ -22,13 +22,13 @@ git clone https://github.com/wso2/docker-apim.git
 
 - Navigate to `<ANALYTICS_DOCKERFILE_HOME>` directory. <br>
   Execute `docker build` command as shown below.
-    + `docker build -t wso2am-analytics-worker:2.6.0 .`
+    + `docker build -t wso2am-analytics-worker:3.0.0 .`
     
 > By default, the Docker image will prepackage the General Availability (GA) release version of the relevant WSO2 product.
     
 ##### 3. Running Docker images specific to each profile.
 
-- `docker run -p 9091:9091 wso2am-analytics-worker:2.6.0`
+- `docker run -p 9091:9091 wso2am-analytics-worker:3.0.0`
 > Here, only port 9091 has been mapped to a Docker host port.
 You may map other container service ports, which have been exposed to Docker host ports, as desired.
 
@@ -39,7 +39,7 @@ As an example, steps required to change the port offset using `deployment.yaml` 
 
 ##### 1. Stop the Identity Server Analytics container if it's already running.
 
-In WSO2 API Manager Analytics 2.6.0 product distribution, `deployment.yaml` configuration file <br>
+In WSO2 API Manager Analytics 3.0.0 product distribution, `deployment.yaml` configuration file <br>
 can be found at `<DISTRIBUTION_HOME>/conf/worker`. Copy the file to some suitable location of the host machine, <br>
 referred to as `<SOURCE_CONFIGS>/deployment.yaml` and change the offset value under ports to 2.
 
@@ -55,10 +55,10 @@ chmod o+r <SOURCE_CONFIGS>/deployment.yaml
 docker run 
 -p 7713:7713
 --volume <SOURCE_CONFIGS>/deployment.yaml:<TARGET_CONFIGS>/deployment.yaml
-wso2am-analytics-worker:2.6.0
+wso2am-analytics-worker:3.0.0
 ```
 
-> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2am-analytics-2.6.0/conf/worker folder of the container.
+> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2am-analytics-3.0.0/conf/worker folder of the container.
 
 ## Docker command usage references
 

--- a/dockerfiles/ubuntu/apim/Dockerfile
+++ b/dockerfiles/ubuntu/apim/Dockerfile
@@ -29,12 +29,12 @@ ARG USER_GROUP_ID=802
 ARG USER_HOME=/home/${USER}
 # build arguments for WSO2 product installation
 ARG WSO2_SERVER_NAME=wso2am
-ARG WSO2_SERVER_VERSION=2.6.0
+ARG WSO2_SERVER_VERSION=3.0.0
 ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
 ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
 ARG WSO2_SERVER_DIST_URL=https://bintray.com/wso2/binaryGA/download_file?file_path=${WSO2_SERVER}.zip
 # build arguments for external artifacts
-ARG MYSQL_CONNECTOR_VERSION=5.1.47
+ARG MYSQL_CONNECTOR_VERSION=8.0.17
 # build argument for MOTD
 ARG MOTD="\n\
 Welcome to WSO2 Docker resources.\n\
@@ -48,14 +48,6 @@ RUN \
     groupadd --system -g ${USER_GROUP_ID} ${USER_GROUP} \
     && useradd --system --create-home --home-dir ${USER_HOME} --no-log-init -g ${USER_GROUP_ID} -u ${USER_ID} ${USER} \
     && echo '[ ! -z "${TERM}" -a -r /etc/motd ] && cat /etc/motd' >> /etc/bash.bashrc; echo "${MOTD}" > /etc/motd
-
-# create Java prefs dir
-# this is to avoid warning logs printed by FileSystemPreferences class
-RUN \
-    mkdir -p ${USER_HOME}/.java/.systemPrefs \
-    && mkdir -p ${USER_HOME}/.java/.userPrefs \
-    && chmod -R 755 ${USER_HOME}/.java \
-    && chown -R ${USER}:${USER_GROUP} ${USER_HOME}/.java
 
 # copy init script to user home
 COPY --chown=wso2carbon:wso2 docker-entrypoint.sh ${USER_HOME}/
@@ -85,8 +77,7 @@ USER ${USER_ID}
 WORKDIR ${USER_HOME}
 
 # set environment variables
-ENV JAVA_OPTS="-Djava.util.prefs.systemRoot=${USER_HOME}/.java -Djava.util.prefs.userRoot=${USER_HOME}/.java/.userPrefs" \
-    WORKING_DIRECTORY=${USER_HOME} \
+ENV WORKING_DIRECTORY=${USER_HOME} \
     WSO2_SERVER_HOME=${WSO2_SERVER_HOME}
 
 # expose ports

--- a/dockerfiles/ubuntu/apim/README.md
+++ b/dockerfiles/ubuntu/apim/README.md
@@ -1,6 +1,6 @@
 # Dockerfile for WSO2 API Manager #
 
-This section defines the step-by-step instructions to build an [Ubuntu](https://hub.docker.com/_/ubuntu/) Linux based Docker image for WSO2 API Manager 2.6.0.
+This section defines the step-by-step instructions to build an [Ubuntu](https://hub.docker.com/_/ubuntu/) Linux based Docker image for WSO2 API Manager 3.0.0.
 
 ## Prerequisites
 
@@ -21,13 +21,13 @@ git clone https://github.com/wso2/docker-apim.git
 
 - Navigate to `<AM_DOCKERFILE_HOME>` directory. <br>
   Execute `docker build` command as shown below.
-    + `docker build -t wso2am:2.6.0 .`
+    + `docker build -t wso2am:3.0.0 .`
     
 > By default, the Docker image will prepackage the General Availability (GA) release version of the relevant WSO2 product.
     
 ##### 3. Running the Docker image.
 
-- `docker run -it -p 9443:9443 wso2am:2.6.0`
+- `docker run -it -p 9443:9443 wso2am:3.0.0`
 > Here, only port 9443 (HTTPS servlet transport) has been mapped to a Docker host port.
 You may map other container service ports, which have been exposed to Docker host ports, as desired.
 
@@ -41,18 +41,18 @@ You may map other container service ports, which have been exposed to Docker hos
 ## How to update configurations
 
 Configurations would lie on the Docker host machine and they can be volume mounted to the container. <br>
-As an example, steps required to change the port offset using `carbon.xml` is as follows:
+As an example, steps required to change the port offset using `deployment.toml` is as follows:
 
 ##### 1. Stop the API Manager container if it's already running.
 
-In WSO2 API Manager 2.6.0 product distribution, `carbon.xml` configuration file <br>
+In WSO2 API Manager 3.0.0 product distribution, `deployment.toml` configuration file <br>
 can be found at `<DISTRIBUTION_HOME>/repository/conf`. Copy the file to some suitable location of the host machine, <br>
-referred to as `<SOURCE_CONFIGS>/carbon.xml` and change the offset value under ports to 1.
+referred to as `<SOURCE_CONFIGS>/deployment.toml` and change the offset value (`[server]->offset`) to 1.
 
-##### 2. Grant read permission to `other` users for `<SOURCE_CONFIGS>/carbon.xml`.
+##### 2. Grant read permission to `other` users for `<SOURCE_CONFIGS>/deployment.toml`.
 
 ```
-chmod o+r <SOURCE_CONFIGS>/carbon.xml
+chmod o+r <SOURCE_CONFIGS>/deployment.toml
 ```
 
 ##### 3. Run the image by mounting the file to container as follows:
@@ -60,11 +60,11 @@ chmod o+r <SOURCE_CONFIGS>/carbon.xml
 ```
 docker run \
 -p 9444:9444 \
---volume <SOURCE_CONFIGS>/carbon.xml:<TARGET_CONFIGS>/carbon.xml \
-wso2am:2.6.0
+--volume <SOURCE_CONFIGS>/deployment.toml:<TARGET_CONFIGS>/deployment.toml \
+wso2am:3.0.0
 ```
 
-> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2am-2.6.0/repository/conf folder of the container.
+> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2am-3.0.0/repository/conf folder of the container.
 
 ## Docker command usage references
 

--- a/dockerfiles/ubuntu/is-as-km/Dockerfile
+++ b/dockerfiles/ubuntu/is-as-km/Dockerfile
@@ -29,14 +29,14 @@ ARG USER_GROUP_ID=802
 ARG USER_HOME=/home/${USER}
 # build arguments for WSO2 product installation
 ARG WSO2_SERVER_NAME=wso2is-km
-ARG WSO2_SERVER_VERSION=5.7.0
+ARG WSO2_SERVER_VERSION=5.9.0
 ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
 ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
 ARG WSO2_SERVER_DIST_URL=https://bintray.com/wso2/binaryGA/download_file?file_path=${WSO2_SERVER}.zip
 # build arguments for external artifacts
 ARG DNS_JAVA_VERSION=2.1.8
 ARG K8S_MEMBERSHIP_SCHEME_VERSION=1.0.5
-ARG MYSQL_CONNECTOR_VERSION=5.1.47
+ARG MYSQL_CONNECTOR_VERSION=8.0.17
 # build argument for MOTD
 ARG MOTD="\n\
 Welcome to WSO2 Docker resources.\n\
@@ -50,13 +50,6 @@ RUN \
     groupadd --system -g ${USER_GROUP_ID} ${USER_GROUP} \
     && useradd --system --create-home --home-dir ${USER_HOME} --no-log-init -g ${USER_GROUP_ID} -u ${USER_ID} ${USER} \
     && echo '[ ! -z "${TERM}" -a -r /etc/motd ] && cat /etc/motd' >> /etc/bash.bashrc; echo "${MOTD}" > /etc/motd
-
-# create Java prefs dir
-# this is to avoid warning logs printed by FileSystemPreferences class
-RUN mkdir -p ${USER_HOME}/.java/.systemPrefs && \
-    mkdir -p ${USER_HOME}/.java/.userPrefs && \
-    chmod -R 755 ${USER_HOME}/.java && \
-    chown -R ${USER}:${USER_GROUP} ${USER_HOME}/.java
 
 # copy init script to user home
 COPY --chown=wso2carbon:wso2 docker-entrypoint.sh ${USER_HOME}/
@@ -85,8 +78,7 @@ USER ${USER_ID}
 WORKDIR ${USER_HOME}
 
 # set environment variables
-ENV JAVA_OPTS="-Djava.util.prefs.systemRoot=${USER_HOME}/.java -Djava.util.prefs.userRoot=${USER_HOME}/.java/.userPrefs" \
-    WORKING_DIRECTORY=${USER_HOME} \
+ENV WORKING_DIRECTORY=${USER_HOME} \
     WSO2_SERVER_HOME=${WSO2_SERVER_HOME}
 
 # expose ports

--- a/dockerfiles/ubuntu/is-as-km/README.md
+++ b/dockerfiles/ubuntu/is-as-km/README.md
@@ -20,13 +20,13 @@ git clone https://github.com/wso2/docker-apim.git
 
 - Navigate to `<IS_KM_DOCKERFILE_HOME>` directory. <br>
   Execute `docker build` command as shown below.
-    + `docker build -t wso2is-km:5.7.0 .`
+    + `docker build -t wso2is-km:5.9.0 .`
     
 > By default, the Docker image will prepackage the General Availability (GA) release version of the relevant WSO2 product.
     
 ##### 3. Running the Docker image.
 
-- `docker run -it -p 9443:9443 wso2is-km:5.7.0`
+- `docker run -it -p 9443:9443 wso2is-km:5.9.0`
 
 ##### 4. Accessing management console.
 
@@ -38,18 +38,18 @@ git clone https://github.com/wso2/docker-apim.git
 ## How to update configurations
 
 Configurations would lie on the Docker host machine and they can be volume mounted to the container. <br>
-As an example, steps required to change the port offset using `carbon.xml` is as follows:
+As an example, steps required to change the port offset using `deployment.toml` is as follows:
 
 ##### 1. Stop the Identity Server as Key Manager container if it's already running.
 
-In WSO2 Identity Server as Key Manager 5.7.0 product distribution, `carbon.xml` configuration file <br>
+In WSO2 Identity Server as Key Manager 5.9.0 product distribution, `deployment.toml` configuration file <br>
 can be found at `<DISTRIBUTION_HOME>/repository/conf`. Copy the file to some suitable location of the host machine, <br>
-referred to as `<SOURCE_CONFIGS>/carbon.xml` and change the offset value under ports to 1.
+referred to as `<SOURCE_CONFIGS>/deployment.toml` and change the offset value (`[server]->offset`) to 1.
 
-##### 2. Grant read permission to `other` users for `<SOURCE_CONFIGS>/carbon.xml`.
+##### 2. Grant read permission to `other` users for `<SOURCE_CONFIGS>/deployment.toml`.
 
 ```
-chmod o+r <SOURCE_CONFIGS>/carbon.xml
+chmod o+r <SOURCE_CONFIGS>/deployment.toml
 ```
 
 ##### 3. Run the image by mounting the file to container as follows:
@@ -57,11 +57,11 @@ chmod o+r <SOURCE_CONFIGS>/carbon.xml
 ```
 docker run \
 -p 9444:9444 \
---volume <SOURCE_CONFIGS>/carbon.xml:<TARGET_CONFIGS>/carbon.xml \
-wso2is-km:5.7.0
+--volume <SOURCE_CONFIGS>/deployment.toml:<TARGET_CONFIGS>/deployment.toml \
+wso2is-km:5.9.0
 ```
 
-> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2is-km-5.7.0/repository/conf folder of the container.
+> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2is-km-5.9.0/repository/conf folder of the container.
 
 ## Docker command usage references
 


### PR DESCRIPTION
## Purpose
> Create Docker resources for WSO2 API Management profiles v3.0.0. Also, this introduces the metadata file required by the infrastructure resource generator. This fixes https://github.com/wso2/docker-apim/issues/241 and fixes https://github.com/wso2/docker-apim/issues/243.

## Goals
> Create Docker resources for WSO2 API Management profiles v3.0.0