### PR TITLE
[API-Manager v2.6.x] Failure to accept product startup options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project 2.6.x per each release will be documented in
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
-## [v2.6.0.7] - TBA
+## [v2.6.0.8] - TBA
 
 ### Fixed
 - Failure to accept product startup options

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project 2.6.x per each release will be documented in
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## [v2.6.0.7] - TBA
+
+### Fixed
+- Failure to accept product startup options
+
+For detailed information on the tasks carried out during this release, please see the GitHub milestone
+[v2.6.0.8](https://github.com/wso2/docker-apim/milestone/6).
+
 ## [v2.6.0.7] - 2019-08-28
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,3 @@
-
 # Contributing to docker-apim
 
 Docker and Docker Compose resources for WSO2 API Management platform are open source and we encourage contributions from our community.

--- a/README.md
+++ b/README.md
@@ -2,24 +2,18 @@
 
 This repository contains following Docker resources:
 
-- WSO2 API Manager Dockerfile for Ubuntu
-- WSO2 API Manager Analytics Dockerfile for Ubuntu
-- WSO2 API Manager Identity Server as Key Manager Dockerfile for Ubuntu
-- Docker Compose files to evaluate most common deployment profiles
+- Alpine, CentOS and Ubuntu based Docker resources for WSO2 API Manager, API Manager Analytics Dashboard and Worker and
+Identity Server as Key Manager profiles
+- Docker Compose resources for the most common WSO2 API Management deployment patterns
 
-Docker resources for WSO2 API Manager, WSO2 API Manager Analytics and WSO2 API Manager Identity Server as Key Manager
+Docker resources for WSO2 API Manager, API Manager Analytics and WSO2 Identity Server as Key Manager
 help you build generic Docker images for deploying the corresponding product servers in containerized environments.
 Each Docker image includes the JDK, the relevant product distribution and a collection of utility libraries.Configurations, custom JDBC
 drivers other than the default MySQL JDBC driver provided, extensions and other deployable artifacts are designed to be
 provided via volume mounts to the containers spawned.
 
-Docker Compose files have been created according to the most common API Manager deployment profiles available for allowing users to quickly evaluate
-product features along side their co-operate API management requirements. The Compose files make use of
-Docker images of WSO2 API Manager, WSO2 API Manager Analytics, WSO2 API Manager Identity Server as Key Manager and MySQL.
+Docker Compose files have been created according to the most common API Management deployment patterns available for allowing users
+to quickly evaluate product features along side their co-operate API Management requirements. The Compose files make use of per profile
+Docker images of WSO2 API Manager, API Manager Analytics and WSO2 Identity Server as Key Manager, as well as MySQL.
 
-**Change log** from previous v2.6.0.6 release: [View Here](CHANGELOG.md)
-
-## Reporting issues
-
-We encourage you to report any issues and documentation faults regarding Docker and Docker Compose resources for WSO2 API Management.
-Please report your issues [here](https://github.com/wso2/docker-apim/issues).
+**Change log** from previous v2.6.0.7 release: [View Here](CHANGELOG.md)

--- a/docker-compose/apim-is-as-km-with-analytics/README.md
+++ b/docker-compose/apim-is-as-km-with-analytics/README.md
@@ -1,6 +1,5 @@
 # WSO2 API Manager with Identity Server as Key Manager
 
-
 ## Prerequisites
 
  * Install [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git), [Docker](https://www.docker.com/get-docker) and [Docker Compose](https://docs.docker.com/compose/install/#install-compose)
@@ -17,6 +16,7 @@
     ```
     git clone https://github.com/wso2/docker-apim
     ```
+    
     > If you are to try out an already released zip of this repo, please ignore this 1st step. 
 
 2. Switch to the `docker-compose/apim-is-as-km-with-analytics` folder.
@@ -24,11 +24,12 @@
     ```
     cd docker-apim/docker-compose/apim-is-as-km-with-analytics
     ```
+    
     > If you are to try out an already released zip of this repo, please ignore this 2nd step also. 
-     Instead, extract the zip file and directly browse to `docker-apim-<released-version-here>docker-compose/apim-is-as-km-with-analytics` folder. 
+     Instead, extract the zip file and directly browse to `docker-apim-<released-version-here>/docker-compose/apim-is-as-km-with-analytics` folder. 
      
     > If you want to try out an already released tag, after executing 2nd step, checkout the relevant tag, 
-     i.e. for example: git checkout tags/v2.6.0.3 and continue below steps.
+     i.e. for example: git checkout tags/v2.6.0.8 and continue below steps.
 
 3. [Optional] If you are using WSO2 product Docker images with WSO2 updates, replace the WSO2 product Docker image names
    (relevant `image` attribute under each WSO2 product profile service) in the Docker Compose deployment definition.
@@ -36,6 +37,7 @@
   **Note**: By default, each product profile service is configured to use WSO2 product Docker images with GA releases.
 
 4. Execute following Docker Compose command to start the deployment.
+
    ```
    docker-compose up
    ```
@@ -55,6 +57,7 @@
  * Password: admin
  
  Please note that API Gateway will be available on following ports.
+ 
  ```
     https://localhost:8243
     https://localhost:8280

--- a/docker-compose/apim-is-as-km-with-analytics/scripts/README.md
+++ b/docker-compose/apim-is-as-km-with-analytics/scripts/README.md
@@ -1,6 +1,5 @@
 # WSO2 API Manager with Identity Server as Key Manager
 
-
 ## Prerequisites
 
  * Install [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git), [Docker](https://www.docker.com/get-docker) and [Docker Compose](https://docs.docker.com/compose/install/#install-compose)
@@ -17,6 +16,7 @@
     ```
     git clone https://github.com/wso2/docker-apim
     ```
+    
     > If you are to try out an already released zip of this repo, please ignore this 1st step. 
 
 2. Switch to the `docker-compose/apim-is-as-km-with-analytics` folder.
@@ -24,13 +24,15 @@
     ```
     cd docker-apim/docker-compose/apim-is-as-km-with-analytics
     ```
+    
     > If you are to try out an already released zip of this repo, please ignore this 2nd step also. 
-     Instead, extract the zip file and directly browse to `docker-apim-<released-version-here>docker-compose/apim-is-as-km-with-analytics` folder. 
+     Instead, extract the zip file and directly browse to `docker-apim-<released-version-here>/docker-compose/apim-is-as-km-with-analytics` folder. 
      
     > If you want to try out an already released tag, after executing 2nd step, checkout the relevant tag, 
-     i.e. for example: git checkout tags/v2.6.0.3 and continue below steps.
+     i.e. for example: git checkout tags/v2.6.0.8 and continue below steps.
 
 3. Execute the `deploy.sh` script to start the deployment.
+
      ```
      ./deploy.sh
      ```
@@ -50,6 +52,7 @@
  * Password: admin
  
  Please note that API Gateway will be available on following ports.
+ 
  ```
     https://localhost:8243
     https://localhost:8280

--- a/docker-compose/apim-with-analytics/README.md
+++ b/docker-compose/apim-with-analytics/README.md
@@ -20,6 +20,7 @@
    ```
    git clone https://github.com/wso2/docker-apim
    ```
+   
    > If you are to try out an already released zip of this repo, please ignore this 1st step. 
    
 2. Switch to `docker-compose/apim-with-analytics` folder.
@@ -27,11 +28,12 @@
    ```
    cd docker-apim/docker-compose/apim-with-analytics
    ```
+   
    > If you are to try out an already released zip of this repo, please ignore this 2nd step also. 
-    Instead, extract the zip file and directly browse to `docker-apim-<released-version-here>docker-compose/apim-with-analytics` folder. 
+    Instead, extract the zip file and directly browse to `docker-apim-<released-version-here>/docker-compose/apim-with-analytics` folder. 
      
    > If you want to try out an already released tag, after executing 2nd step, checkout the relevant tag, 
-    i.e. for example: git checkout tags/v2.6.0.3 and continue below steps.
+    i.e. for example: git checkout tags/v2.6.0.8 and continue below steps.
 
 3. [Optional] If you are using WSO2 product Docker images with WSO2 updates, replace the WSO2 product Docker image names
    (relevant `image` attribute under each WSO2 product profile service) in the Docker Compose deployment definition.
@@ -39,6 +41,7 @@
   **Note**: By default, each product profile service is configured to use WSO2 product Docker images with GA releases.
 
 4. Execute following Docker Compose command to start the deployment.
+
    ```
    docker-compose up
    ```
@@ -51,12 +54,14 @@
    https://localhost:9443/admin
    https://localhost:9443/carbon
    ```
+   
    Access the servers using following credentials.
    
    * Username: admin <br>
    * Password: admin
 
    Please note that API Gateway will be available on following ports.
+   
    ```
    https://localhost:8243
    https://localhost:8280

--- a/docker-compose/apim-with-analytics/scripts/README.md
+++ b/docker-compose/apim-with-analytics/scripts/README.md
@@ -18,6 +18,7 @@
    ```
    git clone https://github.com/wso2/docker-apim
    ```
+   
    > If you are to try out an already released zip of this repo, please ignore this 1st step. 
    
 2. Switch to `docker-compose/apim-with-analytics` folder.
@@ -25,13 +26,15 @@
    ```
    cd docker-apim/docker-compose/apim-with-analytics
    ```
+   
    > If you are to try out an already released zip of this repo, please ignore this 2nd step also. 
-    Instead, extract the zip file and directly browse to `docker-apim-<released-version-here>docker-compose/apim-with-analytics` folder. 
+    Instead, extract the zip file and directly browse to `docker-apim-<released-version-here>/docker-compose/apim-with-analytics` folder. 
      
    > If you want to try out an already released tag, after executing 2nd step, checkout the relevant tag, 
-    i.e. for example: git checkout tags/v2.6.0.3 and continue below steps.
+    i.e. for example: git checkout tags/v2.6.0.8 and continue below steps.
 
 3. Execute the `deploy.sh` script to start the deployment.
+
      ```
      ./deploy.sh
      ```
@@ -44,12 +47,14 @@
    https://localhost:9443/admin
    https://localhost:9443/carbon
    ```
+   
    Access the servers using following credentials.
    
    * Username: admin <br>
    * Password: admin
 
    Please note that API Gateway will be available on following ports.
+   
    ```
    https://localhost:8243
    https://localhost:8280

--- a/dockerfiles/alpine/apim/Dockerfile
+++ b/dockerfiles/alpine/apim/Dockerfile
@@ -63,6 +63,7 @@ COPY --chown=wso2carbon:wso2 docker-entrypoint.sh ${USER_HOME}/
 # install required packages
 RUN \
     apk add --no-cache \
+        bash \
         libxml2-utils \
         netcat-openbsd
 # add the WSO2 product distribution to user's home directory

--- a/dockerfiles/alpine/apim/docker-entrypoint.sh
+++ b/dockerfiles/alpine/apim/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # ------------------------------------------------------------------------
 # Copyright 2018 WSO2, Inc. (http://wso2.com)
 #
@@ -32,14 +32,13 @@ test ! -d ${WORKING_DIRECTORY} && echo "WSO2 Docker non-root user home does not 
 test ! -d ${WSO2_SERVER_HOME} && echo "WSO2 Docker product home does not exist" && exit 1
 
 # shared artifact directories
-set "executionplans" "synapse-configs"
+directories=("executionplans" "synapse-configs")
 # if the original directory locations of artifacts to be synced between nodes are empty,
 # copy the preserved, default content of these folders to these original locations
-for shared_directory
-do
+for shared_directory in ${directories[@]}; do
   if test -d ${original_deployment_artifacts}/${shared_directory};
   then
-    if [ -z "$(ls -A ${deployment_volume}/${shared_directory})" ]; then
+    if [[ -z "$(ls -A ${deployment_volume}/${shared_directory})" ]]; then
       if ! cp -R ${original_deployment_artifacts}/${shared_directory}/* ${deployment_volume}/${shared_directory};
       then
         echo "Failed to copy the preserved, default artifacts to original location (${deployment_volume}/${shared_directory})"
@@ -51,9 +50,9 @@ do
 done
 
 # copy any configuration changes mounted to config_volume
-test -d ${config_volume} && [ "$(ls -A ${config_volume})" ] && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
+test -d ${config_volume} && [[ "$(ls -A ${config_volume})" ]] && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
 # copy any artifact changes mounted to artifact_volume
-test -d ${artifact_volume} && [ "$(ls -A ${artifact_volume})" ] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
+test -d ${artifact_volume} && [[ "$(ls -A ${artifact_volume})" ]] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
 # start WSO2 Carbon server
 sh ${WSO2_SERVER_HOME}/bin/wso2server.sh "$@"

--- a/dockerfiles/centos/apim/docker-entrypoint.sh
+++ b/dockerfiles/centos/apim/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # ------------------------------------------------------------------------
 # Copyright 2018 WSO2, Inc. (http://wso2.com)
 #
@@ -32,14 +32,13 @@ test ! -d ${WORKING_DIRECTORY} && echo "WSO2 Docker non-root user home does not 
 test ! -d ${WSO2_SERVER_HOME} && echo "WSO2 Docker product home does not exist" && exit 1
 
 # shared artifact directories
-set "executionplans" "synapse-configs"
+directories=("executionplans" "synapse-configs")
 # if the original directory locations of artifacts to be synced between nodes are empty,
 # copy the preserved, default content of these folders to these original locations
-for shared_directory
-do
+for shared_directory in ${directories[@]}; do
   if test -d ${original_deployment_artifacts}/${shared_directory};
   then
-    if [ -z "$(ls -A ${deployment_volume}/${shared_directory})" ]; then
+    if [[ -z "$(ls -A ${deployment_volume}/${shared_directory})" ]]; then
       if ! cp -R ${original_deployment_artifacts}/${shared_directory}/* ${deployment_volume}/${shared_directory};
       then
         echo "Failed to copy the preserved, default artifacts to original location (${deployment_volume}/${shared_directory})"
@@ -51,9 +50,9 @@ do
 done
 
 # copy any configuration changes mounted to config_volume
-test -d ${config_volume} && [ "$(ls -A ${config_volume})" ] && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
+test -d ${config_volume} && [[ "$(ls -A ${config_volume})" ]] && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
 # copy any artifact changes mounted to artifact_volume
-test -d ${artifact_volume} && [ "$(ls -A ${artifact_volume})" ] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
+test -d ${artifact_volume} && [[ "$(ls -A ${artifact_volume})" ]] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
 # start WSO2 Carbon server
 sh ${WSO2_SERVER_HOME}/bin/wso2server.sh "$@"

--- a/dockerfiles/ubuntu/apim/docker-entrypoint.sh
+++ b/dockerfiles/ubuntu/apim/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # ------------------------------------------------------------------------
 # Copyright 2018 WSO2, Inc. (http://wso2.com)
 #
@@ -32,14 +32,13 @@ test ! -d ${WORKING_DIRECTORY} && echo "WSO2 Docker non-root user home does not 
 test ! -d ${WSO2_SERVER_HOME} && echo "WSO2 Docker product home does not exist" && exit 1
 
 # shared artifact directories
-set "executionplans" "synapse-configs"
+directories=("executionplans" "synapse-configs")
 # if the original directory locations of artifacts to be synced between nodes are empty,
 # copy the preserved, default content of these folders to these original locations
-for shared_directory
-do
+for shared_directory in ${directories[@]}; do
   if test -d ${original_deployment_artifacts}/${shared_directory};
   then
-    if [ -z "$(ls -A ${deployment_volume}/${shared_directory})" ]; then
+    if [[ -z "$(ls -A ${deployment_volume}/${shared_directory})" ]]; then
       if ! cp -R ${original_deployment_artifacts}/${shared_directory}/* ${deployment_volume}/${shared_directory};
       then
         echo "Failed to copy the preserved, default artifacts to original location (${deployment_volume}/${shared_directory})"
@@ -51,9 +50,9 @@ do
 done
 
 # copy any configuration changes mounted to config_volume
-test -d ${config_volume} && [ "$(ls -A ${config_volume})" ] && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
+test -d ${config_volume} && [[ "$(ls -A ${config_volume})" ]] && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
 # copy any artifact changes mounted to artifact_volume
-test -d ${artifact_volume} && [ "$(ls -A ${artifact_volume})" ] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
+test -d ${artifact_volume} && [[ "$(ls -A ${artifact_volume})" ]] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
 # start WSO2 Carbon server
 sh ${WSO2_SERVER_HOME}/bin/wso2server.sh "$@"


### PR DESCRIPTION
## Purpose
> It has been discovered that the WSO2 API Manager version 2.6.x Docker images fail to accept product startup options. This PR fixes the original issue https://github.com/wso2/docker-apim/issues/250.

## Goals
> Fix failure to accept product startup options