### PR TITLE
[API-Manager v3.0.x] Failure to accept product startup options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project 3.0.x per each release will be documented in
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## [v3.0.0.2] - TBA
+
+### Fixed
+- Failure to accept product startup options
+
+For detailed information on the tasks carried out during this release, please see the GitHub milestone
+[v3.0.0.2](https://github.com/wso2/docker-apim/milestone/9).
+
 ## [v3.0.0.1] - 2019-10-28
 
 ### Added
@@ -13,4 +21,4 @@ and Identity Server as Key Manager version 5.9.x profiles
 For detailed information on the tasks carried out during this release, please see the GitHub milestone
 [v3.0.0.1](https://github.com/wso2/docker-apim/milestone/7).
 
-[v3.0.0.1]: https://github.com/wso2/docker-apim/compare/v2.6.0.7...v3.0.0.1
+[v3.0.0.2]: https://github.com/wso2/docker-apim/compare/v3.0.0.1...v3.0.0.2

--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ Docker Compose files have been created according to the most common API Manageme
 to quickly evaluate product features along side their co-operate API Management requirements. The Compose files make use of per profile
 Docker images of WSO2 API Manager, API Manager Analytics and WSO2 Identity Server as Key Manager, as well as MySQL.
 
-**Change log** from previous v2.6.0.7 release: [View Here](CHANGELOG.md)
+**Change log** from previous v3.0.0.1 release: [View Here](CHANGELOG.md)

--- a/dockerfiles/alpine/apim/Dockerfile
+++ b/dockerfiles/alpine/apim/Dockerfile
@@ -55,6 +55,7 @@ COPY --chown=wso2carbon:wso2 docker-entrypoint.sh ${USER_HOME}/
 # install required packages
 RUN \
     apk add --no-cache \
+        bash \
         libxml2-utils \
         netcat-openbsd
 # add the WSO2 product distribution to user's home directory

--- a/dockerfiles/alpine/apim/docker-entrypoint.sh
+++ b/dockerfiles/alpine/apim/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # ------------------------------------------------------------------------
 # Copyright 2018 WSO2, Inc. (http://wso2.com)
 #
@@ -32,14 +32,13 @@ test ! -d ${WORKING_DIRECTORY} && echo "WSO2 Docker non-root user home does not 
 test ! -d ${WSO2_SERVER_HOME} && echo "WSO2 Docker product home does not exist" && exit 1
 
 # shared artifact directories
-set "executionplans" "synapse-configs"
+directories=("executionplans" "synapse-configs")
 # if the original directory locations of artifacts to be synced between nodes are empty,
 # copy the preserved, default content of these folders to these original locations
-for shared_directory
-do
+for shared_directory in ${directories[@]}; do
   if test -d ${original_deployment_artifacts}/${shared_directory};
   then
-    if [ -z "$(ls -A ${deployment_volume}/${shared_directory})" ]; then
+    if [[ -z "$(ls -A ${deployment_volume}/${shared_directory})" ]]; then
       if ! cp -R ${original_deployment_artifacts}/${shared_directory}/* ${deployment_volume}/${shared_directory};
       then
         echo "Failed to copy the preserved, default artifacts to original location (${deployment_volume}/${shared_directory})"
@@ -51,9 +50,9 @@ do
 done
 
 # copy any configuration changes mounted to config_volume
-test -d ${config_volume} && [ "$(ls -A ${config_volume})" ] && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
+test -d ${config_volume} && [[ "$(ls -A ${config_volume})" ]] && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
 # copy any artifact changes mounted to artifact_volume
-test -d ${artifact_volume} && [ "$(ls -A ${artifact_volume})" ] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
+test -d ${artifact_volume} && [[ "$(ls -A ${artifact_volume})" ]] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
 # start WSO2 Carbon server
 sh ${WSO2_SERVER_HOME}/bin/wso2server.sh "$@"

--- a/dockerfiles/centos/apim/docker-entrypoint.sh
+++ b/dockerfiles/centos/apim/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # ------------------------------------------------------------------------
 # Copyright 2018 WSO2, Inc. (http://wso2.com)
 #
@@ -32,14 +32,13 @@ test ! -d ${WORKING_DIRECTORY} && echo "WSO2 Docker non-root user home does not 
 test ! -d ${WSO2_SERVER_HOME} && echo "WSO2 Docker product home does not exist" && exit 1
 
 # shared artifact directories
-set "executionplans" "synapse-configs"
+directories=("executionplans" "synapse-configs")
 # if the original directory locations of artifacts to be synced between nodes are empty,
 # copy the preserved, default content of these folders to these original locations
-for shared_directory
-do
+for shared_directory in ${directories[@]}; do
   if test -d ${original_deployment_artifacts}/${shared_directory};
   then
-    if [ -z "$(ls -A ${deployment_volume}/${shared_directory})" ]; then
+    if [[ -z "$(ls -A ${deployment_volume}/${shared_directory})" ]]; then
       if ! cp -R ${original_deployment_artifacts}/${shared_directory}/* ${deployment_volume}/${shared_directory};
       then
         echo "Failed to copy the preserved, default artifacts to original location (${deployment_volume}/${shared_directory})"
@@ -51,9 +50,9 @@ do
 done
 
 # copy any configuration changes mounted to config_volume
-test -d ${config_volume} && [ "$(ls -A ${config_volume})" ] && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
+test -d ${config_volume} && [[ "$(ls -A ${config_volume})" ]] && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
 # copy any artifact changes mounted to artifact_volume
-test -d ${artifact_volume} && [ "$(ls -A ${artifact_volume})" ] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
+test -d ${artifact_volume} && [[ "$(ls -A ${artifact_volume})" ]] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
 # start WSO2 Carbon server
 sh ${WSO2_SERVER_HOME}/bin/wso2server.sh "$@"

--- a/dockerfiles/ubuntu/apim/docker-entrypoint.sh
+++ b/dockerfiles/ubuntu/apim/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # ------------------------------------------------------------------------
 # Copyright 2018 WSO2, Inc. (http://wso2.com)
 #
@@ -32,14 +32,13 @@ test ! -d ${WORKING_DIRECTORY} && echo "WSO2 Docker non-root user home does not 
 test ! -d ${WSO2_SERVER_HOME} && echo "WSO2 Docker product home does not exist" && exit 1
 
 # shared artifact directories
-set "executionplans" "synapse-configs"
+directories=("executionplans" "synapse-configs")
 # if the original directory locations of artifacts to be synced between nodes are empty,
 # copy the preserved, default content of these folders to these original locations
-for shared_directory
-do
+for shared_directory in ${directories[@]}; do
   if test -d ${original_deployment_artifacts}/${shared_directory};
   then
-    if [ -z "$(ls -A ${deployment_volume}/${shared_directory})" ]; then
+    if [[ -z "$(ls -A ${deployment_volume}/${shared_directory})" ]]; then
       if ! cp -R ${original_deployment_artifacts}/${shared_directory}/* ${deployment_volume}/${shared_directory};
       then
         echo "Failed to copy the preserved, default artifacts to original location (${deployment_volume}/${shared_directory})"
@@ -51,9 +50,9 @@ do
 done
 
 # copy any configuration changes mounted to config_volume
-test -d ${config_volume} && [ "$(ls -A ${config_volume})" ] && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
+test -d ${config_volume} && [[ "$(ls -A ${config_volume})" ]] && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
 # copy any artifact changes mounted to artifact_volume
-test -d ${artifact_volume} && [ "$(ls -A ${artifact_volume})" ] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
+test -d ${artifact_volume} && [[ "$(ls -A ${artifact_volume})" ]] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
 # start WSO2 Carbon server
 sh ${WSO2_SERVER_HOME}/bin/wso2server.sh "$@"


### PR DESCRIPTION
## Purpose
> It has been discovered that the WSO2 API Manager version 3.0.x Docker images fail to accept product startup options. This PR fixes https://github.com/wso2/docker-apim/issues/252.

## Goals
> Fix failure to accept product startup options