### PR TITLE
Rename context portal to analytics-dashboard

### DIFF
--- a/dockerfiles/alpine/apim-analytics/dashboard/README.md
+++ b/dockerfiles/alpine/apim-analytics/dashboard/README.md
@@ -35,7 +35,7 @@ You may map other container service ports, which have been exposed to Docker hos
 ##### 4. Accessing the Dashboard portal.
 
 - For dashboard,
-    + `https:<DOCKER_HOST>:9643/portal`
+    + `https:<DOCKER_HOST>:9643/analytics-dashboard`
     
 > In here, <DOCKER_HOST> refers to hostname or IP of the host machine on top of which containers are spawned.
 

--- a/dockerfiles/centos/apim-analytics/dashboard/README.md
+++ b/dockerfiles/centos/apim-analytics/dashboard/README.md
@@ -35,7 +35,7 @@ You may map other container service ports, which have been exposed to Docker hos
 ##### 4. Accessing the Dashboard portal.
 
 - For dashboard,
-    + `https:<DOCKER_HOST>:9643/portal`
+    + `https:<DOCKER_HOST>:9643/analytics-dashboard`
     
 > In here, <DOCKER_HOST> refers to hostname or IP of the host machine on top of which containers are spawned.
 

--- a/dockerfiles/ubuntu/apim-analytics/dashboard/README.md
+++ b/dockerfiles/ubuntu/apim-analytics/dashboard/README.md
@@ -35,7 +35,7 @@ You may map other container service ports, which have been exposed to Docker hos
 ##### 4. Accessing the Dashboard portal.
 
 - For dashboard,
-    + `https:<DOCKER_HOST>:9643/portal`
+    + `https:<DOCKER_HOST>:9643/analytics-dashboard`
     
 > In here, <DOCKER_HOST> refers to hostname or IP of the host machine on top of which containers are spawned.
 


### PR DESCRIPTION
## Purpose
- New version of analytics dashboard uses the context `/analytics-dashboard` instead of `/portal`. Rename context /portal to /analytics-dashboard