### PR TITLE
[v2.6.x] Preserve the default H2 database data required for Apache Solr indexing process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project 2.6.x per each release will be documented in
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## [v2.6.0.9] - TBA
+
+### Added
+- Preserve the default H2 database data required for Solr indexing process
+
+For detailed information on the tasks carried out during this release, please see the GitHub milestone
+[v2.6.0.9](https://github.com/wso2/docker-apim/milestone/10).
+
 ## [v2.6.0.8] - 2019-11-05
 
 ### Fixed
@@ -75,4 +83,4 @@ For detailed information on the tasks carried out during this release, please se
 - WSO2 API Manager Identity Server as Key Manager v5.7.x Docker resources for Alpine, CentOS and Ubuntu
 - Docker Compose resources for WSO2 API Management
 
-[v2.6.0.7]: https://github.com/wso2/docker-apim/compare/v2.6.0.6...v2.6.0.7
+[v2.6.0.9]: https://github.com/wso2/docker-apim/compare/v2.6.0.8...v2.6.0.9

--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ Docker Compose files have been created according to the most common API Manageme
 to quickly evaluate product features along side their co-operate API Management requirements. The Compose files make use of per profile
 Docker images of WSO2 API Manager, API Manager Analytics and WSO2 Identity Server as Key Manager, as well as MySQL.
 
-**Change log** from previous v2.6.0.7 release: [View Here](CHANGELOG.md)
+**Change log** from previous v2.6.0.9 release: [View Here](CHANGELOG.md)

--- a/dockerfiles/alpine/apim/Dockerfile
+++ b/dockerfiles/alpine/apim/Dockerfile
@@ -71,9 +71,10 @@ RUN \
     wget --no-check-certificate -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
     && unzip -d ${USER_HOME} ${WSO2_SERVER}.zip \
     && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME} \
-    && mkdir ${USER_HOME}/wso2-tmp \
-    && cp -r ${WSO2_SERVER_HOME}/repository/deployment/server/synapse-configs ${USER_HOME}/wso2-tmp \
-    && cp -r ${WSO2_SERVER_HOME}/repository/deployment/server/executionplans ${USER_HOME}/wso2-tmp \
+    && mkdir -p ${USER_HOME}/wso2-tmp/deployment/server \
+    && cp -r ${WSO2_SERVER_HOME}/repository/deployment/server/synapse-configs ${USER_HOME}/wso2-tmp/deployment/server \
+    && cp -r ${WSO2_SERVER_HOME}/repository/deployment/server/executionplans ${USER_HOME}/wso2-tmp/deployment/server \
+    && cp -r ${WSO2_SERVER_HOME}/repository/database ${USER_HOME}/wso2-tmp \
     && rm -f ${WSO2_SERVER}.zip
 # add MySQL JDBC connector to server home as a third party library
 ADD --chown=wso2carbon:wso2 http://central.maven.org/maven2/mysql/mysql-connector-java/${MYSQL_CONNECTOR_VERSION}/mysql-connector-java-${MYSQL_CONNECTOR_VERSION}.jar ${WSO2_SERVER_HOME}/repository/components/dropins/

--- a/dockerfiles/alpine/apim/docker-entrypoint.sh
+++ b/dockerfiles/alpine/apim/docker-entrypoint.sh
@@ -21,7 +21,7 @@ set -e
 config_volume=${WORKING_DIRECTORY}/wso2-config-volume
 artifact_volume=${WORKING_DIRECTORY}/wso2-artifact-volume
 # home of the directories to be artifact synced within the WSO2 product home
-deployment_volume=${WSO2_SERVER_HOME}/repository/deployment/server
+deployment_volume=${WSO2_SERVER_HOME}/repository
 # home of the directories with preserved, default deployment artifacts
 original_deployment_artifacts=${WORKING_DIRECTORY}/wso2-tmp
 
@@ -32,7 +32,7 @@ test ! -d ${WORKING_DIRECTORY} && echo "WSO2 Docker non-root user home does not 
 test ! -d ${WSO2_SERVER_HOME} && echo "WSO2 Docker product home does not exist" && exit 1
 
 # shared artifact directories
-directories=("executionplans" "synapse-configs")
+directories=("deployment/server/executionplans" "deployment/server/synapse-configs" "database")
 # if the original directory locations of artifacts to be synced between nodes are empty,
 # copy the preserved, default content of these folders to these original locations
 for shared_directory in ${directories[@]}; do

--- a/dockerfiles/centos/apim/Dockerfile
+++ b/dockerfiles/centos/apim/Dockerfile
@@ -74,9 +74,10 @@ RUN \
     wget --no-check-certificate -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
     && unzip -d ${USER_HOME} ${WSO2_SERVER}.zip \
     && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME} \
-    && mkdir ${USER_HOME}/wso2-tmp \
-    && cp -r ${WSO2_SERVER_HOME}/repository/deployment/server/synapse-configs ${USER_HOME}/wso2-tmp \
-    && cp -r ${WSO2_SERVER_HOME}/repository/deployment/server/executionplans ${USER_HOME}/wso2-tmp \
+    && mkdir -p ${USER_HOME}/wso2-tmp/deployment/server \
+    && cp -r ${WSO2_SERVER_HOME}/repository/deployment/server/synapse-configs ${USER_HOME}/wso2-tmp/deployment/server \
+    && cp -r ${WSO2_SERVER_HOME}/repository/deployment/server/executionplans ${USER_HOME}/wso2-tmp/deployment/server \
+    && cp -r ${WSO2_SERVER_HOME}/repository/database ${USER_HOME}/wso2-tmp \
     && rm -f ${WSO2_SERVER}.zip
 # add MySQL JDBC connector to server home as a third party library
 ADD --chown=wso2carbon:wso2 http://central.maven.org/maven2/mysql/mysql-connector-java/${MYSQL_CONNECTOR_VERSION}/mysql-connector-java-${MYSQL_CONNECTOR_VERSION}.jar ${WSO2_SERVER_HOME}/repository/components/dropins/

--- a/dockerfiles/centos/apim/docker-entrypoint.sh
+++ b/dockerfiles/centos/apim/docker-entrypoint.sh
@@ -21,7 +21,7 @@ set -e
 config_volume=${WORKING_DIRECTORY}/wso2-config-volume
 artifact_volume=${WORKING_DIRECTORY}/wso2-artifact-volume
 # home of the directories to be artifact synced within the WSO2 product home
-deployment_volume=${WSO2_SERVER_HOME}/repository/deployment/server
+deployment_volume=${WSO2_SERVER_HOME}/repository
 # home of the directories with preserved, default deployment artifacts
 original_deployment_artifacts=${WORKING_DIRECTORY}/wso2-tmp
 
@@ -32,7 +32,7 @@ test ! -d ${WORKING_DIRECTORY} && echo "WSO2 Docker non-root user home does not 
 test ! -d ${WSO2_SERVER_HOME} && echo "WSO2 Docker product home does not exist" && exit 1
 
 # shared artifact directories
-directories=("executionplans" "synapse-configs")
+directories=("deployment/server/executionplans" "deployment/server/synapse-configs" "database")
 # if the original directory locations of artifacts to be synced between nodes are empty,
 # copy the preserved, default content of these folders to these original locations
 for shared_directory in ${directories[@]}; do

--- a/dockerfiles/ubuntu/apim/Dockerfile
+++ b/dockerfiles/ubuntu/apim/Dockerfile
@@ -73,9 +73,10 @@ RUN \
     wget --no-check-certificate -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
     && unzip -d ${USER_HOME} ${WSO2_SERVER}.zip \
     && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME} \
-    && mkdir ${USER_HOME}/wso2-tmp \
-    && cp -r ${WSO2_SERVER_HOME}/repository/deployment/server/synapse-configs ${USER_HOME}/wso2-tmp \
-    && cp -r ${WSO2_SERVER_HOME}/repository/deployment/server/executionplans ${USER_HOME}/wso2-tmp \
+    && mkdir -p ${USER_HOME}/wso2-tmp/deployment/server \
+    && cp -r ${WSO2_SERVER_HOME}/repository/deployment/server/synapse-configs ${USER_HOME}/wso2-tmp/deployment/server \
+    && cp -r ${WSO2_SERVER_HOME}/repository/deployment/server/executionplans ${USER_HOME}/wso2-tmp/deployment/server \
+    && cp -r ${WSO2_SERVER_HOME}/repository/database ${USER_HOME}/wso2-tmp \
     && rm -f ${WSO2_SERVER}.zip
 # add MySQL JDBC connector to server home as a third party library
 ADD --chown=wso2carbon:wso2 http://central.maven.org/maven2/mysql/mysql-connector-java/${MYSQL_CONNECTOR_VERSION}/mysql-connector-java-${MYSQL_CONNECTOR_VERSION}.jar ${WSO2_SERVER_HOME}/repository/components/dropins/

--- a/dockerfiles/ubuntu/apim/docker-entrypoint.sh
+++ b/dockerfiles/ubuntu/apim/docker-entrypoint.sh
@@ -21,7 +21,7 @@ set -e
 config_volume=${WORKING_DIRECTORY}/wso2-config-volume
 artifact_volume=${WORKING_DIRECTORY}/wso2-artifact-volume
 # home of the directories to be artifact synced within the WSO2 product home
-deployment_volume=${WSO2_SERVER_HOME}/repository/deployment/server
+deployment_volume=${WSO2_SERVER_HOME}/repository
 # home of the directories with preserved, default deployment artifacts
 original_deployment_artifacts=${WORKING_DIRECTORY}/wso2-tmp
 
@@ -32,7 +32,7 @@ test ! -d ${WORKING_DIRECTORY} && echo "WSO2 Docker non-root user home does not 
 test ! -d ${WSO2_SERVER_HOME} && echo "WSO2 Docker product home does not exist" && exit 1
 
 # shared artifact directories
-directories=("executionplans" "synapse-configs")
+directories=("deployment/server/executionplans" "deployment/server/synapse-configs" "database")
 # if the original directory locations of artifacts to be synced between nodes are empty,
 # copy the preserved, default content of these folders to these original locations
 for shared_directory in ${directories[@]}; do


### PR DESCRIPTION
## Purpose
> This PR preserves the default H2 database data required for Apache Solr indexing process in WSO2 API Manager Docker resources. This fixes https://github.com/wso2/docker-apim/issues/259.

## Goals
> Preserve the default H2 database data required for Apache Solr indexing process