### PR TITLE
[3.2.0] Avoid Creating Directory For Persisting Local Carbon H2 Database File

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Alpine, CentOS and Ubuntu based Docker resources for WSO2 API Manager, API Manager Analytics Dashboard and Worker version `3.2.x`
 - Upgrade AdoptOpenJDK 11 version to the latest version - 11.0.7_10-jdk
 - Remove unnecessary patch volume mount option
+- Avoid creating directory for persisting local Carbon H2 database file
 
 For detailed information on the tasks carried out during this release, please see the GitHub milestone
 [v3.2.0.1](https://github.com/wso2/docker-apim/milestone/17).

--- a/dockerfiles/alpine/apim/Dockerfile
+++ b/dockerfiles/alpine/apim/Dockerfile
@@ -65,7 +65,7 @@ RUN \
     && unzip -d ${USER_HOME} ${WSO2_SERVER}.zip \
     && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME} \
     && mkdir ${USER_HOME}/wso2-tmp \
-    && bash -c 'mkdir -p ${USER_HOME}/solr/{indexed-data,database}' \
+    && mkdir -p ${USER_HOME}/solr/indexed-data \
     && chown wso2carbon:wso2 -R ${USER_HOME}/solr \
     && cp -r ${WSO2_SERVER_HOME}/repository/deployment/server/synapse-configs ${USER_HOME}/wso2-tmp \
     && cp -r ${WSO2_SERVER_HOME}/repository/deployment/server/executionplans ${USER_HOME}/wso2-tmp \

--- a/dockerfiles/centos/apim/Dockerfile
+++ b/dockerfiles/centos/apim/Dockerfile
@@ -66,7 +66,7 @@ RUN \
     && unzip -d ${USER_HOME} ${WSO2_SERVER}.zip \
     && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME} \
     && mkdir ${USER_HOME}/wso2-tmp \
-    && bash -c 'mkdir -p ${USER_HOME}/solr/{indexed-data,database}' \
+    && mkdir -p ${USER_HOME}/solr/indexed-data \
     && chown wso2carbon:wso2 -R ${USER_HOME}/solr \
     && cp -r ${WSO2_SERVER_HOME}/repository/deployment/server/synapse-configs ${USER_HOME}/wso2-tmp \
     && cp -r ${WSO2_SERVER_HOME}/repository/deployment/server/executionplans ${USER_HOME}/wso2-tmp \

--- a/dockerfiles/ubuntu/apim/Dockerfile
+++ b/dockerfiles/ubuntu/apim/Dockerfile
@@ -67,7 +67,7 @@ RUN \
     && unzip -d ${USER_HOME} ${WSO2_SERVER}.zip \
     && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME} \
     && mkdir ${USER_HOME}/wso2-tmp \
-    && bash -c 'mkdir -p ${USER_HOME}/solr/{indexed-data,database}' \
+    && mkdir -p ${USER_HOME}/solr/indexed-data \
     && chown wso2carbon:wso2 -R ${USER_HOME}/solr \
     && cp -r ${WSO2_SERVER_HOME}/repository/deployment/server/synapse-configs ${USER_HOME}/wso2-tmp \
     && cp -r ${WSO2_SERVER_HOME}/repository/deployment/server/executionplans ${USER_HOME}/wso2-tmp \


### PR DESCRIPTION
## Purpose
> This PR removes the creation step of directory for persisting the local Carbon H2 database file. This closes https://github.com/wso2/docker-apim/issues/319.

## Goals
> Avoid Creating Directory For Persisting Local Carbon H2 Database File