### PR TITLE
[2.5.0] Add Git release tag as a label & enable SSL cert verification for wget

### DIFF
--- a/dockerfiles/alpine/apim-analytics/Dockerfile
+++ b/dockerfiles/alpine/apim-analytics/Dockerfile
@@ -86,16 +86,14 @@ RUN \
 # add MySQL JDBC connector to server home as a third party library
 ADD --chown=wso2carbon:wso2 https://repo1.maven.org/maven2/mysql/mysql-connector-java/${MYSQL_CONNECTOR_VERSION}/mysql-connector-java-${MYSQL_CONNECTOR_VERSION}.jar ${WSO2_SERVER_HOME}/repository/components/dropins/
 
-# set environment variables
-ENV WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER_PACK} \
-    JAVA_OPTS="-Djava.util.prefs.systemRoot=${USER_HOME}/.java -Djava.util.prefs.userRoot=${USER_HOME}/.java/.userPrefs"
-
 # set the user and work directory
 USER ${USER_ID}
 WORKDIR ${USER_HOME}
 
 # set environment variables
-ENV WORKING_DIRECTORY=${USER_HOME}
+ENV WORKING_DIRECTORY=${USER_HOME} \
+    WSO2_SERVER_HOME=${WSO2_SERVER_HOME} \
+    JAVA_OPTS="-Djava.util.prefs.systemRoot=${USER_HOME}/.java -Djava.util.prefs.userRoot=${USER_HOME}/.java/.userPrefs"
 
 # expose ports
 EXPOSE 9764 9444 7712 7612 4041

--- a/dockerfiles/alpine/apim-analytics/Dockerfile
+++ b/dockerfiles/alpine/apim-analytics/Dockerfile
@@ -43,6 +43,7 @@ Welcome to WSO2 Docker resources.\n\
 This Docker container comprises of a WSO2 product, running with its latest GA release \n\
 which is under the Apache License, Version 2.0. \n\
 Read more about Apache License, Version 2.0 here @ http://www.apache.org/licenses/LICENSE-2.0.\n"
+ENV ENV=${USER_HOME}"/.ashrc"
 
 # create the non-root user and group and set MOTD login message
 RUN \

--- a/dockerfiles/alpine/apim-analytics/Dockerfile
+++ b/dockerfiles/alpine/apim-analytics/Dockerfile
@@ -30,10 +30,10 @@ ARG USER_HOME=/home/${USER}
 # build arguments for WSO2 product installation
 ARG WSO2_SERVER_NAME=wso2am-analytics
 ARG WSO2_SERVER_VERSION=2.5.0
-ARG WSO2_SERVER_REPOSITORY=product-apim
+ARG WSO2_SERVER_REPOSITORY=analytics-apim
 ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
 ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
-ARG WSO2_SERVER_DIST_URL
+ARG WSO2_SERVER_DIST_URL="https://github.com/wso2/${WSO2_SERVER_REPOSITORY}/releases/download/v${WSO2_SERVER_VERSION}/${WSO2_SERVER}.zip"
 # build arguments for external artifacts
 ARG MYSQL_CONNECTOR_VERSION=5.1.49
 # build argument for MOTD
@@ -76,7 +76,7 @@ RUN mkdir -p ${USER_HOME}/.java/.systemPrefs && \
 
 # add the WSO2 product distribution to user's home directory
 RUN \
-    wget --no-check-certificate -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
+    wget -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
     && unzip -d ${USER_HOME} ${WSO2_SERVER}.zip \
     && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME} \
     && mkdir ${USER_HOME}/wso2-tmp \

--- a/dockerfiles/alpine/apim-analytics/Dockerfile
+++ b/dockerfiles/alpine/apim-analytics/Dockerfile
@@ -18,7 +18,8 @@
 
 # set to latest Alpine
 FROM openjdk:8u171-jdk-alpine3.8
-MAINTAINER WSO2 Docker Maintainers "dev@wso2.org”
+LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
+      com.wso2.docker.source="https://github.com/wso2/docker-apim/releases/tag/v2.5.0.3"
 
 # set user configurations
 ARG USER=wso2carbon

--- a/dockerfiles/alpine/apim-analytics/README.md
+++ b/dockerfiles/alpine/apim-analytics/README.md
@@ -6,10 +6,6 @@ The section defines the step-by-step instructions to build an Alpine OpenJDK Doc
 
 * [Docker](https://www.docker.com/get-docker) v17.09.0 or above
 * [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) client
-* WSO2 API Manager Analytics downloaded through [WUM](https://wso2.com/wum/download)
-* Download JDK 8 through [Oracle](https://www.oracle.com/java/technologies/javase/javase-jdk8-downloads.html)
-  - Host the downloaded pack and JDK locally or on a remote location.
->The hosted product pack location and JDK location will be passed as the build arguments WSO2_SERVER_DIST_URL and JDK_URL when building the Docker image.
 
 ## How to build an image and run
 ##### 1. Checkout this repository into your local machine using the following git command.
@@ -26,10 +22,8 @@ in order to obtain latest bug fixes and updates for the product.
 - Navigate to `<ANALYTICS_DOCKERFILE_HOME>` directory. <br>
   Execute `docker build` command as shown below.
 
-  + `docker build --build-arg WSO2_SERVER_DIST_URL=<URL_OF_THE_HOSTED_LOCATION/FILENAME> JDK_URL=<URL_OF_THE_HOSTED_JDK_LOCATION/FILENAME> -t wso2am-analytics:2.5.0-alpine .`
-    - eg:- Hosted locally: docker build --build-arg WSO2_SERVER_DIST_URL=http://172.17.0.1:8000/wso2am-analytics.zip JDK_URL=http://172.17.0.1:8000/jdk-8u261-linux-x64.tar.gz -t wso2am-analytics:2.5.0-alpine . 
-    - eg:- Hosted remotely: docker build --build-arg WSO2_SERVER_DIST_URL=http://<public_ip:port>/wso2am-analytics.zip JDK_URL=http://172.17.0.1:8000/jdk-8u261-linux-x64.tar.gz -t wso2am-analytics:2.5.0-alpine .
-  
+  + `docker build -t wso2am-analytics:2.5.0-alpine .`
+
 ##### 3. Running the Docker image.
 - docker run -it -p 9444:9444 wso2am-analytics:2.5.0-alpine
 

--- a/dockerfiles/alpine/apim-analytics/README.md
+++ b/dockerfiles/alpine/apim-analytics/README.md
@@ -8,7 +8,7 @@ The section defines the step-by-step instructions to build an Alpine OpenJDK Doc
 * [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) client
 
 ## How to build an image and run
-##### 1. Checkout this repository into your local machine using the following git command.
+##### 1. Checkout this repository into your local machine using the following Git command.
 ```
 git clone https://github.com/wso2/docker-apim.git
 ```

--- a/dockerfiles/alpine/apim/Dockerfile
+++ b/dockerfiles/alpine/apim/Dockerfile
@@ -33,7 +33,7 @@ ARG WSO2_SERVER_VERSION=2.5.0
 ARG WSO2_SERVER_REPOSITORY=product-apim
 ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
 ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
-ARG WSO2_SERVER_DIST_URL
+ARG WSO2_SERVER_DIST_URL="https://github.com/wso2/product-apim/releases/download/v${WSO2_SERVER_VERSION}/${WSO2_SERVER}.zip"
 # build arguments for external artifacts
 ARG MYSQL_CONNECTOR_VERSION=5.1.49
 # build argument for MOTD
@@ -70,7 +70,7 @@ RUN \
 
 # add the WSO2 product distribution to user's home directory
 RUN \
-    wget --no-check-certificate -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
+    wget -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
     && unzip -d ${USER_HOME} ${WSO2_SERVER}.zip \
     && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME} \
     && mkdir ${USER_HOME}/wso2-tmp \

--- a/dockerfiles/alpine/apim/Dockerfile
+++ b/dockerfiles/alpine/apim/Dockerfile
@@ -43,6 +43,7 @@ Welcome to WSO2 Docker resources.\n\
 This Docker container comprises of a WSO2 product, running with its latest GA release \n\
 which is under the Apache License, Version 2.0. \n\
 Read more about Apache License, Version 2.0 here @ http://www.apache.org/licenses/LICENSE-2.0.\n"
+ENV ENV=${USER_HOME}"/.ashrc"
 
 # create the non-root user and group and set MOTD login message
 RUN \

--- a/dockerfiles/alpine/apim/Dockerfile
+++ b/dockerfiles/alpine/apim/Dockerfile
@@ -18,7 +18,8 @@
 
 # set to latest Alpine
 FROM openjdk:8u171-jdk-alpine3.8
-MAINTAINER WSO2 Docker Maintainers "dev@wso2.org”
+LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
+      com.wso2.docker.source="https://github.com/wso2/docker-apim/releases/tag/v2.5.0.3"
 
 # set user configurations
 ARG USER=wso2carbon
@@ -27,7 +28,7 @@ ARG USER_GROUP=wso2
 ARG USER_GROUP_ID=802
 ARG USER_HOME=/home/${USER}
 # set wso2 product configurations
-ARG WSO2_SERVER=wso2am
+ARG WSO2_SERVER_NAME=wso2am
 ARG WSO2_SERVER_VERSION=2.5.0
 ARG WSO2_SERVER_REPOSITORY=product-apim
 ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}

--- a/dockerfiles/alpine/apim/README.md
+++ b/dockerfiles/alpine/apim/README.md
@@ -5,11 +5,6 @@ This section defines the step-by-step instructions to build an Alpine OpenJDK  D
 
 * [Docker](https://www.docker.com/get-docker) v17.09.0 or above
 * [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) client
-* WSO2 API Manager pack downloaded through [WUM](https://wso2.com/wum/download) 
-* Download JDK 8 through [Oracle](https://www.oracle.com/java/technologies/javase/javase-jdk8-downloads.html)
-  - Host the downloaded pack and JDK locally or on a remote location.
->The hosted product pack location and JDK location will be passed as the build arguments WSO2_SERVER_DIST_URL and JDK_URL when building the Docker image.
-
 ## How to build an image and run
 ##### 1. Checkout this repository into your local machine using the following git command.
 ```
@@ -25,10 +20,8 @@ in order to obtain latest bug fixes and updates for the product.
 - Navigate to `<AM_DOCKERFILE_HOME>` directory. <br>
   Execute `docker build` command as shown below.
 
-  + `docker build --build-arg WSO2_SERVER_DIST_URL=<URL_OF_THE_HOSTED_LOCATION/FILENAME> JDK_URL=<URL_OF_THE_HOSTED_JDK_LOCATION/FILENAME> -t wso2am:2.5.0-alpine .`
-    - eg:- Hosted locally: docker build --build-arg WSO2_SERVER_DIST_URL=http://172.17.0.1:8000/wso2am-2.5.0.zip JDK_URL=http://172.17.0.1:8000/jdk-8u261-linux-x64.tar.gz -t wso2am:2.5.0-alpine . 
-    - eg:- Hosted remotely: docker build --build-arg WSO2_SERVER_DIST_URL=http://<public_ip:port>/wso2am-2.5.0.zip JDK_URL=http://172.17.0.1:8000/jdk-8u261-linux-x64.tar.gz -t wso2am:2.5.0-alpine .
-   
+  + `docker build -t wso2am:2.5.0-alpine .`
+
 ##### 3. Running the Docker image.
 - `docker run -it -p 9443:9443 wso2am:2.5.0-alpine`
 

--- a/dockerfiles/alpine/apim/README.md
+++ b/dockerfiles/alpine/apim/README.md
@@ -6,7 +6,7 @@ This section defines the step-by-step instructions to build an Alpine OpenJDK  D
 * [Docker](https://www.docker.com/get-docker) v17.09.0 or above
 * [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) client
 ## How to build an image and run
-##### 1. Checkout this repository into your local machine using the following git command.
+##### 1. Checkout this repository into your local machine using the following Git command.
 ```
 git clone https://github.com/wso2/docker-apim.git
 ```

--- a/dockerfiles/alpine/is-as-km/Dockerfile
+++ b/dockerfiles/alpine/is-as-km/Dockerfile
@@ -83,16 +83,14 @@ ADD --chown=wso2carbon:wso2 https://repo1.maven.org/maven2/mysql/mysql-connector
 ADD --chown=wso2carbon:wso2 https://repo1.maven.org/maven2/dnsjava/dnsjava/2.1.8/dnsjava-2.1.8.jar ${WSO2_SERVER_HOME}/repository/components/lib/
 ADD --chown=wso2carbon:wso2 https://repo1.maven.org/maven2/org/wso2/carbon/kubernetes/artifacts/kubernetes-membership-scheme/1.0.5/kubernetes-membership-scheme-1.0.5.jar ${WSO2_SERVER_HOME}/repository/components/dropins/
 
-# set environment variables
-ENV WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER_PACK} \
-    JAVA_OPTS="-Djava.util.prefs.systemRoot=${USER_HOME}/.java -Djava.util.prefs.userRoot=${USER_HOME}/.java/.userPrefs"
-
 # set the user and work directory
 USER ${USER_ID}
 WORKDIR ${USER_HOME}
 
 # set environment variables
-ENV WORKING_DIRECTORY=${USER_HOME}
+ENV WORKING_DIRECTORY=${USER_HOME} \
+    WSO2_SERVER_HOME=${WSO2_SERVER_HOME} \
+    JAVA_OPTS="-Djava.util.prefs.systemRoot=${USER_HOME}/.java -Djava.util.prefs.userRoot=${USER_HOME}/.java/.userPrefs"
 
 # expose ports
 EXPOSE 9763 9443

--- a/dockerfiles/alpine/is-as-km/Dockerfile
+++ b/dockerfiles/alpine/is-as-km/Dockerfile
@@ -31,9 +31,10 @@ ARG USER_HOME=/home/${USER}
 ARG WSO2_SERVER_NAME=wso2is-km
 ARG WSO2_SERVER_VERSION=5.6.0
 ARG WSO2_SERVER_REPOSITORY=product-apim
+ARG WSO2_SERVER_REPOSITORY_RELEASE_VERSION=2.5.0
 ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
 ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
-ARG WSO2_SERVER_DIST_URL
+ARG WSO2_SERVER_DIST_URL="https://github.com/wso2/product-apim/releases/download/v${WSO2_SERVER_REPOSITORY_RELEASE_VERSION}/${WSO2_SERVER}.zip"
 # build arguments for external artifacts
 ARG MYSQL_CONNECTOR_VERSION=5.1.49
 # build argument for MOTD
@@ -69,7 +70,7 @@ RUN mkdir -p ${USER_HOME}/.java/.systemPrefs && \
 
 # add the WSO2 product distribution to user's home directory
 RUN \
-    wget --no-check-certificate -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
+    wget -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
     && unzip -d ${USER_HOME} ${WSO2_SERVER}.zip \
     && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME} \
     && mkdir ${USER_HOME}/wso2-tmp \

--- a/dockerfiles/alpine/is-as-km/Dockerfile
+++ b/dockerfiles/alpine/is-as-km/Dockerfile
@@ -44,6 +44,7 @@ Welcome to WSO2 Docker resources.\n\
 This Docker container comprises of a WSO2 product, running with its latest GA release \n\
 which is under the Apache License, Version 2.0. \n\
 Read more about Apache License, Version 2.0 here @ http://www.apache.org/licenses/LICENSE-2.0.\n"
+ENV ENV=${USER_HOME}"/.ashrc"
 
 # create the non-root user and group and set MOTD login message
 RUN \

--- a/dockerfiles/alpine/is-as-km/Dockerfile
+++ b/dockerfiles/alpine/is-as-km/Dockerfile
@@ -18,7 +18,8 @@
 
 # set to latest Alpine
 FROM openjdk:8u171-jdk-alpine3.8
-MAINTAINER WSO2 Docker Maintainers "dev@wso2.org”
+LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
+      com.wso2.docker.source="https://github.com/wso2/docker-apim/releases/tag/v2.5.0.3"
 
 # set user configurations
 ARG USER=wso2carbon

--- a/dockerfiles/alpine/is-as-km/README.md
+++ b/dockerfiles/alpine/is-as-km/README.md
@@ -5,10 +5,6 @@ The section defines the step-by-step instructions to build the Docker image for 
 
 * [Docker](https://www.docker.com/get-docker) v17.09.0 or above
 * [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) client
-* WSO2 API Key Manager pack downloaded through [WUM](https://wso2.com/wum/download)
-* Download JDK 8 through [Oracle](https://www.oracle.com/java/technologies/javase/javase-jdk8-downloads.html)
-  - Host the downloaded pack and JDK locally or on a remote location.
->The hosted product pack location and JDK location will be passed as the build arguments WSO2_SERVER_DIST_URL and JDK_URL when building the Docker image.
 
 ## How to build an image and run
 ##### 1. Checkout this repository into your local machine using the following git command.
@@ -25,10 +21,8 @@ in order to obtain latest bug fixes and updates for the product.
 - Navigate to `<IS_KM_DOCKERFILE_HOME>` directory. <br>
   Execute `docker build` command as shown below.
 
-  + `docker build --build-arg WSO2_SERVER_DIST_URL=<URL_OF_THE_HOSTED_LOCATION/FILENAME> JDK_URL=<URL_OF_THE_HOSTED_JDK_LOCATION/FILENAME> -t wso2is-km:5.6.0-alpine .`
-    - eg:- Hosted locally: docker build --build-arg WSO2_SERVER_DIST_URL=http://172.17.0.1:8000/wso2is-km.zip JDK_URL=http://172.17.0.1:8000/jdk-8u261-linux-x64.tar.gz -t wso2is-km:5.6.0-alpine . 
-    - eg:- Hosted remotely: docker build --build-arg WSO2_SERVER_DIST_URL=http://<public_ip:port>/wso2is-km.zip JDK_URL=http://172.17.0.1:8000/jdk-8u261-linux-x64.tar.gz -t wso2is-km:5.6.0-alpine .
-      
+  + `docker build --build-arg -t wso2is-km:5.6.0-alpine .`
+
 ##### 3. Running the Docker image.
 - `docker run -it -p 9443:9443 wso2is-km:5.6.0-alpine`
 

--- a/dockerfiles/alpine/is-as-km/README.md
+++ b/dockerfiles/alpine/is-as-km/README.md
@@ -7,7 +7,7 @@ The section defines the step-by-step instructions to build the Docker image for 
 * [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) client
 
 ## How to build an image and run
-##### 1. Checkout this repository into your local machine using the following git command.
+##### 1. Checkout this repository into your local machine using the following Git command.
 ```
 git clone https://github.com/wso2/docker-apim.git
 ```

--- a/dockerfiles/centos/apim-analytics/Dockerfile
+++ b/dockerfiles/centos/apim-analytics/Dockerfile
@@ -33,10 +33,10 @@ ARG JDK_NAME=jdk-8u261-linux-x64.tar.gz
 # build arguments for WSO2 product installation
 ARG WSO2_SERVER_NAME=wso2am-analytics
 ARG WSO2_SERVER_VERSION=2.5.0
-ARG WSO2_SERVER_REPOSITORY=product-apim
+ARG WSO2_SERVER_REPOSITORY=analytics-apim
 ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
 ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
-ARG WSO2_SERVER_DIST_URL
+ARG WSO2_SERVER_DIST_URL="https://github.com/wso2/${WSO2_SERVER_REPOSITORY}/releases/download/v${WSO2_SERVER_VERSION}/${WSO2_SERVER}.zip"
 ARG JDK_URL
 # build arguments for external artifacts
 ARG MYSQL_CONNECTOR_VERSION=5.1.49
@@ -69,14 +69,14 @@ RUN \
 # installe Oracle JDK
 RUN \
     mkdir -p ${JAVA_HOME} \
-    && wget --no-check-certificate -O ${JDK_NAME} ${JDK_URL} \
+    && wget -O ${JDK_NAME} ${JDK_URL} \
     && tar -xf ${JDK_NAME} -C ${JAVA_HOME} --strip-components=1 \
     && chown wso2carbon:wso2 -R ${JAVA_HOME} \
     && rm -f ${JDK_NAME}
 
 # add the WSO2 product distribution to user's home directory
 RUN \
-    wget --no-check-certificate -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
+    wget -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
     && unzip -d ${USER_HOME} ${WSO2_SERVER}.zip \
     && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME} \
     && mkdir ${USER_HOME}/wso2-tmp \

--- a/dockerfiles/centos/apim-analytics/Dockerfile
+++ b/dockerfiles/centos/apim-analytics/Dockerfile
@@ -18,7 +18,8 @@
 
 # set to latest Centos
 FROM centos:7
-MAINTAINER WSO2 Docker Maintainers "dev@wso2.org"
+LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
+      com.wso2.docker.source="https://github.com/wso2/docker-apim/releases/tag/v2.5.0.3"
 
 # set user configurations
 ARG USER=wso2carbon

--- a/dockerfiles/centos/apim-analytics/README.md
+++ b/dockerfiles/centos/apim-analytics/README.md
@@ -5,10 +5,9 @@ The section defines the step-by-step instructions to build a CentOS Linux based 
 
 * [Docker](https://www.docker.com/get-docker) v17.09.0 or above
 * [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) client
-* WSO2 API Manager Analytics pack downloaded through [WUM](https://wso2.com/wum/download)
 * Download JDK 8 through [Oracle](https://www.oracle.com/java/technologies/javase/javase-jdk8-downloads.html)
-  - Host the downloaded pack and JDK locally or on a remote location.
->The hosted product pack location and JDK location will be passed as the build arguments WSO2_SERVER_DIST_URL and JDK_URL when building the Docker image.
+  - Host the downloaded JDK locally or on a remote location.
+>The hosted JDK location will be passed as the build argument JDK_URL when building the Docker image.
 
 ## How to build an image and run
 ##### 1. Checkout this repository into your local machine using the following git command.
@@ -25,9 +24,9 @@ in order to obtain latest bug fixes and updates for the product.
 - Navigate to `<ANALYTICS_DOCKERFILE_HOME>` directory. <br>
   Execute `docker build` command as shown below.
 
-  + `docker build --build-arg WSO2_SERVER_DIST_URL=<URL_OF_THE_HOSTED_LOCATION/FILENAME> JDK_URL=<URL_OF_THE_HOSTED_JDK_LOCATION/FILENAME> -t wso2am-analytics:2.5.0-centos .`
-    - eg:- Hosted locally: docker build --build-arg WSO2_SERVER_DIST_URL=http://172.17.0.1:8000/wso2am-analytics-2.5.0.zip JDK_URL=http://172.17.0.1:8000/jdk-8u261-linux-x64.tar.gz -t wso2am-analytics:2.5.0-centos . 
-    - eg:- Hosted remotely: docker build --build-arg WSO2_SERVER_DIST_URL=http://<public_ip:port>/wso2am-analytics-2.5.0.zip JDK_URL=http://172.17.0.1:8000/jdk-8u261-linux-x64.tar.gz -t wso2am-analytics:2.5.0-centos .
+  + `docker build --build-arg JDK_URL=<URL_OF_THE_HOSTED_JDK_LOCATION/FILENAME> -t wso2am-analytics:2.5.0-centos .`
+    - eg:- Hosted locally: docker build --build-arg JDK_URL=http://172.17.0.1:8000/jdk-8u261-linux-x64.tar.gz -t wso2am-analytics:2.5.0-centos . 
+    - eg:- Hosted remotely: docker build --build-arg JDK_URL=http://172.17.0.1:8000/jdk-8u261-linux-x64.tar.gz -t wso2am-analytics:2.5.0-centos .
  
 ##### 3. Running the Docker image.
 - `docker run -it -p 9444:9444 wso2am-analytics:2.5.0-centos`

--- a/dockerfiles/centos/apim-analytics/README.md
+++ b/dockerfiles/centos/apim-analytics/README.md
@@ -10,7 +10,7 @@ The section defines the step-by-step instructions to build a CentOS Linux based 
 >The hosted JDK location will be passed as the build argument JDK_URL when building the Docker image.
 
 ## How to build an image and run
-##### 1. Checkout this repository into your local machine using the following git command.
+##### 1. Checkout this repository into your local machine using the following Git command.
 ```
 git clone https://github.com/wso2/docker-apim.git
 ```

--- a/dockerfiles/centos/apim/Dockerfile
+++ b/dockerfiles/centos/apim/Dockerfile
@@ -18,7 +18,8 @@
 
 # set to latest Centos
 FROM centos:7
-MAINTAINER WSO2 Docker Maintainers "dev@wso2.org"
+LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
+      com.wso2.docker.source="https://github.com/wso2/docker-apim/releases/tag/v2.5.0.3"
 
 # set user configurations
 ARG USER=wso2carbon

--- a/dockerfiles/centos/apim/Dockerfile
+++ b/dockerfiles/centos/apim/Dockerfile
@@ -36,7 +36,7 @@ ARG WSO2_SERVER_VERSION=2.5.0
 ARG WSO2_SERVER_REPOSITORY=product-apim
 ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
 ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
-ARG WSO2_SERVER_DIST_URL
+ARG WSO2_SERVER_DIST_URL="https://github.com/wso2/product-apim/releases/download/v${WSO2_SERVER_VERSION}/${WSO2_SERVER}.zip"
 ARG JDK_URL
 # build arguments for external artifacts
 ARG MYSQL_CONNECTOR_VERSION=5.1.49
@@ -69,14 +69,14 @@ RUN \
 # installe Oracle JDK
 RUN \
     mkdir -p ${JAVA_HOME} \
-    && wget --no-check-certificate -O ${JDK_NAME} ${JDK_URL} \
+    && wget -O ${JDK_NAME} ${JDK_URL} \
     && tar -xf ${JDK_NAME} -C ${JAVA_HOME} --strip-components=1 \
     && chown wso2carbon:wso2 -R ${JAVA_HOME} \
     && rm -f ${JDK_NAME}
 
 # add the WSO2 product distribution to user's home directory
 RUN \
-    wget --no-check-certificate -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
+    wget -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
     && unzip -d ${USER_HOME} ${WSO2_SERVER}.zip \
     && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME} \
     && mkdir ${USER_HOME}/wso2-tmp \

--- a/dockerfiles/centos/apim/README.md
+++ b/dockerfiles/centos/apim/README.md
@@ -5,10 +5,9 @@ The section defines the step-by-step instructions to build a [CentOS](https://hu
 
 * [Docker](https://www.docker.com/get-docker) v17.09.0 or above
 * [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) client
-* WSO2 API Manager pack downloaded through [WUM](https://wso2.com/wum/download)
 * Download JDK 8 through [Oracle](https://www.oracle.com/java/technologies/javase/javase-jdk8-downloads.html)
-  - Host the downloaded pack and JDK locally or on a remote location.
->The hosted product pack location and JDK location will be passed as the build arguments WSO2_SERVER_DIST_URL and JDK_URL when building the Docker image.
+  - Host the downloaded JDK locally or on a remote location.
+>The hosted JDK location will be passed as the build argument JDK_URL when building the Docker image.
 
 ## How to build an image and run
 ##### 1. Checkout this repository into your local machine using the following git command.
@@ -26,9 +25,9 @@ in order to obtain latest bug fixes and updates for the product.
 - Navigate to `<AM_DOCKERFILE_HOME>` directory. <br>
   Execute `docker build` command as shown below.
 
-  + `docker build --build-arg WSO2_SERVER_DIST_URL=<URL_OF_THE_HOSTED_LOCATION/FILENAME> JDK_URL=<URL_OF_THE_HOSTED_JDK_LOCATION/FILENAME> -t wso2am:2.5.0-centos .`
-    - eg:- Hosted locally: docker build --build-arg WSO2_SERVER_DIST_URL=http://172.17.0.1:8000/wso2am-2.5.0.zip JDK_URL=http://172.17.0.1:8000/jdk-8u261-linux-x64.tar.gz -t wso2am:2.5.0-centos . 
-    - eg:- Hosted remotely: docker build --build-arg WSO2_SERVER_DIST_URL=http://<public_ip:port>/wso2am-2.5.0.zip JDK_URL=http://172.17.0.1:8000/jdk-8u261-linux-x64.tar.gz -t wso2am:2.5.0-centos .
+  + `docker build --build-arg JDK_URL=<URL_OF_THE_HOSTED_JDK_LOCATION/FILENAME> -t wso2am:2.5.0-centos .`
+    - eg:- Hosted locally: docker build --build-arg JDK_URL=http://172.17.0.1:8000/jdk-8u261-linux-x64.tar.gz -t wso2am:2.5.0-centos . 
+    - eg:- Hosted remotely: docker build --build-arg JDK_URL=http://172.17.0.1:8000/jdk-8u261-linux-x64.tar.gz -t wso2am:2.5.0-centos .
      
 ##### 3. Running the Docker image.
 - `docker run -it -p 9443:9443 wso2am:2.5.0-centos`

--- a/dockerfiles/centos/apim/README.md
+++ b/dockerfiles/centos/apim/README.md
@@ -10,7 +10,7 @@ The section defines the step-by-step instructions to build a [CentOS](https://hu
 >The hosted JDK location will be passed as the build argument JDK_URL when building the Docker image.
 
 ## How to build an image and run
-##### 1. Checkout this repository into your local machine using the following git command.
+##### 1. Checkout this repository into your local machine using the following Git command.
 ```
 git clone https://github.com/wso2/docker-apim.git
 ```

--- a/dockerfiles/centos/is-as-km/Dockerfile
+++ b/dockerfiles/centos/is-as-km/Dockerfile
@@ -18,7 +18,8 @@
 
 # set to latest Centos
 FROM centos:7
-MAINTAINER WSO2 Docker Maintainers "dev@wso2.org"
+LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
+      com.wso2.docker.source="https://github.com/wso2/docker-apim/releases/tag/v2.5.0.3"
 
 # set user configurations
 ARG USER=wso2carbon

--- a/dockerfiles/centos/is-as-km/Dockerfile
+++ b/dockerfiles/centos/is-as-km/Dockerfile
@@ -34,9 +34,10 @@ ARG JDK_NAME=jdk-8u261-linux-x64.tar.gz
 ARG WSO2_SERVER_NAME=wso2is-km
 ARG WSO2_SERVER_VERSION=5.6.0
 ARG WSO2_SERVER_REPOSITORY=product-apim
+ARG WSO2_SERVER_REPOSITORY_RELEASE_VERSION=2.5.0
 ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
 ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
-ARG WSO2_SERVER_DIST_URL
+ARG WSO2_SERVER_DIST_URL="https://github.com/wso2/product-apim/releases/download/v${WSO2_SERVER_REPOSITORY_RELEASE_VERSION}/${WSO2_SERVER}.zip"
 ARG JDK_URL
 # build arguments for external artifacts
 ARG MYSQL_CONNECTOR_VERSION=5.1.49
@@ -69,14 +70,14 @@ RUN \
 # installe Oracle JDK
 RUN \
     mkdir -p ${JAVA_HOME} \
-    && wget --no-check-certificate -O ${JDK_NAME} ${JDK_URL} \
+    && wget -O ${JDK_NAME} ${JDK_URL} \
     && tar -xf ${JDK_NAME} -C ${JAVA_HOME} --strip-components=1 \
     && chown wso2carbon:wso2 -R ${JAVA_HOME} \
     && rm -f ${JDK_NAME}
 
 # add the WSO2 product distribution to user's home directory
 RUN \
-    wget --no-check-certificate -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
+    wget -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
     && unzip -d ${USER_HOME} ${WSO2_SERVER}.zip \
     && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME} \
     && mkdir ${USER_HOME}/wso2-tmp \

--- a/dockerfiles/centos/is-as-km/README.md
+++ b/dockerfiles/centos/is-as-km/README.md
@@ -4,10 +4,9 @@ The section defines the step-by-step instructions to build the Docker image for 
 ## Prerequisites
 * [Docker](https://www.docker.com/get-docker) v17.09.0 or above
 * [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) client
-* WSO2 API Key Manager pack downloaded through [WUM](https://wso2.com/wum/download)
 * Download JDK 8 through [Oracle](https://www.oracle.com/java/technologies/javase/javase-jdk8-downloads.html)
-  - Host the downloaded pack and JDK locally or on a remote location.
->The hosted product pack location and JDK location will be passed as the build arguments WSO2_SERVER_DIST_URL and JDK_URL when building the Docker image.
+  - Host the downloaded JDK locally or on a remote location.
+>The hosted JDK location will be passed as the build argument JDK_URL when building the Docker image.
 
 ## How to build an image and run
 ##### 1. Checkout this repository into your local machine using the following git command.
@@ -24,9 +23,9 @@ in order to obtain latest bug fixes and updates for the product.
 - Navigate to `<IS_KM_DOCKERFILE_HOME>` directory. <br>
   Execute `docker build` command as shown below.
 
-  + `docker build --build-arg WSO2_SERVER_DIST_URL=<URL_OF_THE_HOSTED_LOCATION/FILENAME> JDK_URL=<URL_OF_THE_HOSTED_JDK_LOCATION/FILENAME> -t wso2is-km:5.6.0-centos .`
-    - eg:- Hosted locally: docker build --build-arg WSO2_SERVER_DIST_URL=http://172.17.0.1:8000/wso2am-analytics-2.5.0.zip JDK_URL=http://172.17.0.1:8000/jdk-8u261-linux-x64.tar.gz -t wso2is-km:5.6.0-centos .
-    - eg:- Hosted remotely: docker build --build-arg WSO2_SERVER_DIST_URL=http://<public_ip:port>/wso2am-analytics-2.5.0.zip JDK_URL=http://172.17.0.1:8000/jdk-8u261-linux-x64.tar.gz -t wso2is-km:5.6.0-centos .
+  + `docker build --build-arg JDK_URL=<URL_OF_THE_HOSTED_JDK_LOCATION/FILENAME> -t wso2is-km:5.6.0-centos .`
+    - eg:- Hosted locally: docker build JDK_URL=http://172.17.0.1:8000/jdk-8u261-linux-x64.tar.gz -t wso2is-km:5.6.0-centos .
+    - eg:- Hosted remotely: docker build --build-arg JDK_URL=http://172.17.0.1:8000/jdk-8u261-linux-x64.tar.gz -t wso2is-km:5.6.0-centos .
   
 ##### 3. Running the Docker image.
 - `docker run -it -p 9443:9443 wso2is-km:5.6.0-centos`

--- a/dockerfiles/centos/is-as-km/README.md
+++ b/dockerfiles/centos/is-as-km/README.md
@@ -9,7 +9,7 @@ The section defines the step-by-step instructions to build the Docker image for 
 >The hosted JDK location will be passed as the build argument JDK_URL when building the Docker image.
 
 ## How to build an image and run
-##### 1. Checkout this repository into your local machine using the following git command.
+##### 1. Checkout this repository into your local machine using the following Git command.
 ```
 git clone https://github.com/wso2/docker-apim.git
 ```

--- a/dockerfiles/ubuntu/apim-analytics/Dockerfile
+++ b/dockerfiles/ubuntu/apim-analytics/Dockerfile
@@ -18,7 +18,8 @@
 
 # set to latest Ubuntu LTS
 FROM ubuntu:16.04
-MAINTAINER WSO2 Docker Maintainers "dev@wso2.org"
+LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
+      com.wso2.docker.source="https://github.com/wso2/docker-apim/releases/tag/v2.5.0.3"
 
 # set user configurations
 ARG USER=wso2carbon

--- a/dockerfiles/ubuntu/apim-analytics/Dockerfile
+++ b/dockerfiles/ubuntu/apim-analytics/Dockerfile
@@ -33,10 +33,10 @@ ARG JDK_NAME=jdk-8u261-linux-x64.tar.gz
 # build arguments for WSO2 product installation
 ARG WSO2_SERVER_VERSION=2.5.0
 ARG WSO2_SERVER_NAME=wso2am-analytics
-ARG WSO2_SERVER_REPOSITORY=product-apim
+ARG WSO2_SERVER_REPOSITORY=analytics-apim
 ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
 ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
-ARG WSO2_SERVER_DIST_URL
+ARG WSO2_SERVER_DIST_URL="https://github.com/wso2/${WSO2_SERVER_REPOSITORY}/releases/download/v${WSO2_SERVER_VERSION}/${WSO2_SERVER}.zip"
 ARG JDK_URL
 # build arguments for external artifacts
 ARG MYSQL_CONNECTOR_VERSION=5.1.49
@@ -63,19 +63,20 @@ RUN \
         netcat \
         unzip \
         wget \
+        ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 # installe Oracle JDK
 RUN \
     mkdir -p ${JAVA_HOME} \
-    && wget --no-check-certificate -O ${JDK_NAME} ${JDK_URL} \
+    && wget -O ${JDK_NAME} ${JDK_URL} \
     && tar -xf ${JDK_NAME} -C ${JAVA_HOME} --strip-components=1 \
     && chown wso2carbon:wso2 -R ${JAVA_HOME} \
     && rm -f ${JDK_NAME}
 
 # add the WSO2 product distribution to user's home directory
 RUN \
-    wget --no-check-certificate -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
+    wget -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
     && unzip -d ${USER_HOME} ${WSO2_SERVER}.zip \
     && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME} \
     && mkdir ${USER_HOME}/wso2-tmp \

--- a/dockerfiles/ubuntu/apim-analytics/README.md
+++ b/dockerfiles/ubuntu/apim-analytics/README.md
@@ -4,10 +4,9 @@ This section defines the step-by-step instructions to build an [Ubuntu](https://
 ## Prerequisites
 * [Docker](https://www.docker.com/get-docker) v17.09.0 or above
 * [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) client
-* WSO2 API Manager Analytics pack downloaded through [WUM](https://wso2.com/wum/download)
 * Download JDK 8 through [Oracle](https://www.oracle.com/java/technologies/javase/javase-jdk8-downloads.html)
-  - Host the downloaded pack and JDK locally or on a remote location.
->The hosted product pack location and JDK location will be passed as the build arguments WSO2_SERVER_DIST_URL and JDK_URL when building the Docker image.
+  - Host the downloaded JDK locally or on a remote location.
+>The hosted JDK location will be passed as the build argument JDK_URL when building the Docker image.
 
 ## How to build an image and run
 ##### 1. Checkout this repository into your local machine using the following git command.
@@ -24,9 +23,9 @@ in order to obtain latest bug fixes and updates for the product.
 - Navigate to `<ANALYTICS_DOCKERFILE_HOME>` directory. <br>
   Execute `docker build` command as shown below.
 
-  + `docker build --build-arg WSO2_SERVER_DIST_URL=<URL_OF_THE_HOSTED_LOCATION/FILENAME> JDK_URL=<URL_OF_THE_HOSTED_JDK_LOCATION/FILENAME> -t wso2am-analytics:2.5.0 .`
-    - eg:- Hosted locally: docker build --build-arg WSO2_SERVER_DIST_URL=http://172.17.0.1:8000/wso2am-analytics-2.5.0.zip JDK_URL=http://172.17.0.1:8000/jdk-8u261-linux-x64.tar.gz -t wso2am-analytics:2.5.0 . 
-    - eg:- Hosted remotely: docker build --build-arg WSO2_SERVER_DIST_URL=http://<public_ip:port>/wso2am-analytics-2.5.0.zip JDK_URL=http://172.17.0.1:8000/jdk-8u261-linux-x64.tar.gz -t wso2am-analytics:2.5.0 .
+  + `docker build --build-arg JDK_URL=<URL_OF_THE_HOSTED_JDK_LOCATION/FILENAME> -t wso2am-analytics:2.5.0 .`
+    - eg:- Hosted locally: docker build --build-arg JDK_URL=http://172.17.0.1:8000/jdk-8u261-linux-x64.tar.gz -t wso2am-analytics:2.5.0 . 
+    - eg:- Hosted remotely: docker build --build-arg JDK_URL=http://172.17.0.1:8000/jdk-8u261-linux-x64.tar.gz -t wso2am-analytics:2.5.0 .
     
 ##### 3. Running the Docker image.
 - `docker run -it -p 9444:9444 wso2am-analytics:2.5.0`

--- a/dockerfiles/ubuntu/apim-analytics/README.md
+++ b/dockerfiles/ubuntu/apim-analytics/README.md
@@ -9,7 +9,7 @@ This section defines the step-by-step instructions to build an [Ubuntu](https://
 >The hosted JDK location will be passed as the build argument JDK_URL when building the Docker image.
 
 ## How to build an image and run
-##### 1. Checkout this repository into your local machine using the following git command.
+##### 1. Checkout this repository into your local machine using the following Git command.
 ```
 git clone https://github.com/wso2/docker-apim.git
 ```

--- a/dockerfiles/ubuntu/apim/Dockerfile
+++ b/dockerfiles/ubuntu/apim/Dockerfile
@@ -36,7 +36,7 @@ ARG WSO2_SERVER_VERSION=2.5.0
 ARG WSO2_SERVER_REPOSITORY=product-apim
 ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
 ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
-ARG WSO2_SERVER_DIST_URL
+ARG WSO2_SERVER_DIST_URL="https://github.com/wso2/product-apim/releases/download/v${WSO2_SERVER_VERSION}/${WSO2_SERVER}.zip"
 ARG JDK_URL
 # build arguments for external artifacts
 ARG MYSQL_CONNECTOR_VERSION=5.1.49
@@ -65,19 +65,20 @@ RUN \
         netcat \
         unzip \
         wget \
+        ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 # installe Oracle JDK
 RUN \
     mkdir -p ${JAVA_HOME} \
-    && wget --no-check-certificate -O ${JDK_NAME} ${JDK_URL} \
+    && wget -O ${JDK_NAME} ${JDK_URL} \
     && tar -xf ${JDK_NAME} -C ${JAVA_HOME} --strip-components=1 \
     && chown wso2carbon:wso2 -R ${JAVA_HOME} \
     && rm -f ${JDK_NAME}
 
 # add the WSO2 product distribution to user's home directory
 RUN \
-    wget --no-check-certificate -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
+    wget -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
     && unzip -d ${USER_HOME} ${WSO2_SERVER}.zip \
     && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME} \
     && mkdir ${USER_HOME}/wso2-tmp \

--- a/dockerfiles/ubuntu/apim/Dockerfile
+++ b/dockerfiles/ubuntu/apim/Dockerfile
@@ -18,7 +18,8 @@
 
 # set to latest Ubuntu LTS
 FROM ubuntu:16.04
-MAINTAINER WSO2 Docker Maintainers "dev@wso2.org"
+LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
+      com.wso2.docker.source="https://github.com/wso2/docker-apim/releases/tag/v2.5.0.3"
 
 # set user configurations
 ARG USER=wso2carbon

--- a/dockerfiles/ubuntu/apim/README.md
+++ b/dockerfiles/ubuntu/apim/README.md
@@ -4,10 +4,9 @@ The section defines the step-by-step instructions to build the Docker image for 
 ## Prerequisites
 * [Docker](https://www.docker.com/get-docker) v17.09.0 or above
 * [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) client
-* WSO2 API Manager pack downloaded through [WUM](https://wso2.com/wum/download)
 * Download JDK 8 through [Oracle](https://www.oracle.com/java/technologies/javase/javase-jdk8-downloads.html)
-  - Host the downloaded pack and JDK locally or on a remote location.
->The hosted product pack location and JDK location will be passed as the build arguments WSO2_SERVER_DIST_URL and JDK_URL when building the Docker image.
+  - Host the downloaded JDK locally or on a remote location.
+>The hosted JDK location will be passed as the build argument JDK_URL when building the Docker image.
 
 ## How to build an image and run
 ##### 1. Checkout this repository into your local machine using the following git command.
@@ -24,9 +23,9 @@ in order to obtain latest bug fixes and updates for the product.
 - Navigate to `<AM_DOCKERFILE_HOME>` directory. <br>
   Execute `docker build` command as shown below.
 
-  + `docker build --build-arg WSO2_SERVER_DIST_URL=<URL_OF_THE_HOSTED_LOCATION/FILENAME> JDK_URL=<URL_OF_THE_HOSTED_JDK_LOCATION/FILENAME> -t wso2am:2.5.0 .`
-    - eg:- Hosted locally: docker build --build-arg WSO2_SERVER_DIST_URL=http://172.17.0.1:8000/wso2am-2.5.0.zip JDK_URL=http://172.17.0.1:8000/jdk-8u261-linux-x64.tar.gz -t wso2am:2.5.0 . 
-    - eg:- Hosted remotely: docker build --build-arg WSO2_SERVER_DIST_URL=http://<public_ip:port>/wso2am-2.5.0.zip JDK_URL=http://172.17.0.1:8000/jdk-8u261-linux-x64.tar.gz -t wso2am:2.5.0 .
+  + `docker build --build-arg JDK_URL=<URL_OF_THE_HOSTED_JDK_LOCATION/FILENAME> -t wso2am:2.5.0 .`
+    - eg:- Hosted locally: docker build --build-arg JDK_URL=http://172.17.0.1:8000/jdk-8u261-linux-x64.tar.gz -t wso2am:2.5.0 . 
+    - eg:- Hosted remotely: docker build --build-arg JDK_URL=http://172.17.0.1:8000/jdk-8u261-linux-x64.tar.gz -t wso2am:2.5.0 .
    
 ##### 3. Running the Docker image.
 - `docker run -it -p 9443:9443 wso2am:2.5.0`

--- a/dockerfiles/ubuntu/apim/README.md
+++ b/dockerfiles/ubuntu/apim/README.md
@@ -9,7 +9,7 @@ The section defines the step-by-step instructions to build the Docker image for 
 >The hosted JDK location will be passed as the build argument JDK_URL when building the Docker image.
 
 ## How to build an image and run
-##### 1. Checkout this repository into your local machine using the following git command.
+##### 1. Checkout this repository into your local machine using the following Git command.
 ```
 git clone https://github.com/wso2/docker-apim.git
 ```

--- a/dockerfiles/ubuntu/is-as-km/Dockerfile
+++ b/dockerfiles/ubuntu/is-as-km/Dockerfile
@@ -33,10 +33,11 @@ ARG JDK_NAME=jdk-8u261-linux-x64.tar.gz
 # set wso2 product configurations
 ARG WSO2_SERVER_NAME=wso2is-km
 ARG WSO2_SERVER_VERSION=5.6.0
+ARG WSO2_SERVER_REPOSITORY_RELEASE_VERSION=2.5.0
 ARG WSO2_SERVER_REPOSITORY=product-apim
 ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
 ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
-ARG WSO2_SERVER_DIST_URL
+ARG WSO2_SERVER_DIST_URL="https://github.com/wso2/product-apim/releases/download/v${WSO2_SERVER_REPOSITORY_RELEASE_VERSION}/${WSO2_SERVER}.zip"
 ARG JDK_URL
 # build arguments for external artifacts
 ARG MYSQL_CONNECTOR_VERSION=5.1.49
@@ -64,19 +65,20 @@ RUN \
         netcat \
         unzip \
         wget \
+        ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 # installe Oracle JDK
 RUN \
     mkdir -p ${JAVA_HOME} \
-    && wget --no-check-certificate -O ${JDK_NAME} ${JDK_URL} \
+    && wget -O ${JDK_NAME} ${JDK_URL} \
     && tar -xf ${JDK_NAME} -C ${JAVA_HOME} --strip-components=1 \
     && chown wso2carbon:wso2 -R ${JAVA_HOME} \
     && rm -f ${JDK_NAME}
 
 # add the WSO2 product distribution to user's home directory
 RUN \
-    wget --no-check-certificate -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
+    wget -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
     && unzip -d ${USER_HOME} ${WSO2_SERVER}.zip \
     && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME} \
     && mkdir ${USER_HOME}/wso2-tmp \

--- a/dockerfiles/ubuntu/is-as-km/Dockerfile
+++ b/dockerfiles/ubuntu/is-as-km/Dockerfile
@@ -18,7 +18,8 @@
 
 # set to latest Ubuntu LTS
 FROM ubuntu:16.04
-MAINTAINER WSO2 Docker Maintainers "dev@wso2.org"
+LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
+      com.wso2.docker.source="https://github.com/wso2/docker-apim/releases/tag/v2.5.0.3"
 
 # set user configurations
 ARG USER=wso2carbon

--- a/dockerfiles/ubuntu/is-as-km/README.md
+++ b/dockerfiles/ubuntu/is-as-km/README.md
@@ -9,7 +9,7 @@ The section defines the step-by-step instructions to build the Docker image for 
 >The hosted JDK location will be passed as the build argument JDK_URL when building the Docker image.
 
 ## How to build an image and run
-##### 1. Checkout this repository into your local machine using the following git command.
+##### 1. Checkout this repository into your local machine using the following Git command.
 ```
 git clone https://github.com/wso2/docker-apim.git
 ```

--- a/dockerfiles/ubuntu/is-as-km/README.md
+++ b/dockerfiles/ubuntu/is-as-km/README.md
@@ -4,10 +4,9 @@ The section defines the step-by-step instructions to build the Docker image for 
 ## Prerequisites
 * [Docker](https://www.docker.com/get-docker) v17.09.0 or above
 * [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) client
-* WSO2 API Key Manager downloaded through [WUM](https://wso2.com/wum/download)
 * Download JDK 8 through [Oracle](https://www.oracle.com/java/technologies/javase/javase-jdk8-downloads.html)
-  - Host the downloaded pack and JDK locally or on a remote location.
->The hosted product pack location and JDK location will be passed as the build arguments WSO2_SERVER_DIST_URL and JDK_URL when building the Docker image.
+  - Host the downloaded JDK locally or on a remote location.
+>The hosted JDK location will be passed as the build argument JDK_URL when building the Docker image.
 
 ## How to build an image and run
 ##### 1. Checkout this repository into your local machine using the following git command.
@@ -24,9 +23,9 @@ in order to obtain latest bug fixes and updates for the product.
 - Navigate to `<IS_KM_DOCKERFILE_HOME>` directory. <br>
   Execute `docker build` command as shown below.
 
-  + `docker build --build-arg WSO2_SERVER_DIST_URL=<URL_OF_THE_HOSTED_LOCATION/FILENAME> JDK_URL=<URL_OF_THE_HOSTED_JDK_LOCATION/FILENAME> -t wso2is-km:5.6.0 .`
-    - eg:- Hosted locally: docker build --build-arg WSO2_SERVER_DIST_URL=http://172.17.0.1:8000/wso2is-km-5.6.0.zip JDK_URL=http://172.17.0.1:8000/jdk-8u261-linux-x64.tar.gz -t wso2is-km:5.6.0 .
-    - eg:- Hosted remotely: docker build --build-arg WSO2_SERVER_DIST_URL=http://<public_ip:port>/wso2is-km-5.6.0.zip JDK_URL=http://172.17.0.1:8000/jdk-8u261-linux-x64.tar.gz -t wso2is-km:5.6.0 .
+  + `docker build --build-arg JDK_URL=<URL_OF_THE_HOSTED_JDK_LOCATION/FILENAME> -t wso2is-km:5.6.0 .`
+    - eg:- Hosted locally: docker build --build-arg JDK_URL=http://172.17.0.1:8000/jdk-8u261-linux-x64.tar.gz -t wso2is-km:5.6.0 .
+    - eg:- Hosted remotely: docker build --build-arg JDK_URL=http://172.17.0.1:8000/jdk-8u261-linux-x64.tar.gz -t wso2is-km:5.6.0 .
 
 ##### 3. Running the Docker image.
 - `docker run -it -p 9443:9443 wso2is-km:5.6.0`


### PR DESCRIPTION
## Purpose
> This PR introduces the Docker source Git release tag as a label and enable SSL verification for `wget`. This fixes #358, #359, #362   
## Goals
> Introduce the Docker source Git release tag as a label. 
Enable SSL verification for `wget`.
## Approach
> Use the dockerfile instruction `LABEL` to add Git release tag as a label.
Removes existing option --no-check-certificate for `wget` and update the CA certificates for `Ubuntu 16.04` by installing `ca-certificates` package.
## Test environment
>Client: Docker Engine - Community
 Version:           19.03.12
 API version:       1.40
 Go version:        go1.13.10
 Git commit:        48a66213fe
 Built:             Mon Jun 22 15:45:36 2020
 OS/Arch:           linux/amd64
 Experimental:      false

>Server: Docker Engine - Community
 Engine:
  Version:          19.03.12
  API version:      1.40 (minimum version 1.12)
  Go version:       go1.13.10
  Git commit:       48a66213fe
  Built:            Mon Jun 22 15:44:07 2020
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          1.2.13
  GitCommit:        7ad184331fa3e55e52b890ea95e65ba581ae3429
 runc:
  Version:          1.0.0-rc10
  GitCommit:        dc9208a3303feef5b3839f4323d9beb36df0a9dd
 docker-init:
  Version:          0.18.0
  GitCommit:        fec3683