### PR TITLE
[2.6.0] Upgrade AdoptOpenJDK version to the latest version - jdk8u272-b10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project 2.6.x per each release will be documented in
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## [v2.6.0.11] - 2020-12-01
+
+### Changed
+- Use AdoptOpenJDK version `jdk8u272-b10` in Alpine, CentOS, Ubuntu based Docker resources
+
 ## [v2.6.0.10] - 2020-11-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ Docker Compose files have been created according to the most common API Manageme
 to quickly evaluate product features along side their co-operate API Management requirements. The Compose files make use of per profile
 Docker images of WSO2 API Manager, API Manager Analytics and WSO2 Identity Server as Key Manager, as well as MySQL.
 
-**Change log** from previous v2.6.0.7 release: [View Here](CHANGELOG.md)
+**Change log** from previous v2.6.0.9 release: [View Here](CHANGELOG.md)

--- a/dockerfiles/alpine/apim-analytics/dashboard/Dockerfile
+++ b/dockerfiles/alpine/apim-analytics/dashboard/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Alpine Docker image
-FROM adoptopenjdk/openjdk8:jdk8u222-b10-alpine
+FROM adoptopenjdk/openjdk8:jdk8u272-b10-alpine
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
       com.wso2.docker.source="https://github.com/wso2/docker-apim/releases/tag/v2.6.0.10"
 

--- a/dockerfiles/alpine/apim-analytics/worker/Dockerfile
+++ b/dockerfiles/alpine/apim-analytics/worker/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Alpine Docker image
-FROM adoptopenjdk/openjdk8:jdk8u222-b10-alpine
+FROM adoptopenjdk/openjdk8:jdk8u272-b10-alpine
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
       com.wso2.docker.source="https://github.com/wso2/docker-apim/releases/tag/v2.6.0.10"
 

--- a/dockerfiles/alpine/apim/Dockerfile
+++ b/dockerfiles/alpine/apim/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Alpine Docker image
-FROM adoptopenjdk/openjdk8:jdk8u222-b10-alpine
+FROM adoptopenjdk/openjdk8:jdk8u272-b10-alpine
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
       com.wso2.docker.source="https://github.com/wso2/docker-apim/releases/tag/v2.6.0.10"
 

--- a/dockerfiles/alpine/is-as-km/Dockerfile
+++ b/dockerfiles/alpine/is-as-km/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Alpine Docker image
-FROM adoptopenjdk/openjdk8:jdk8u222-b10-alpine
+FROM adoptopenjdk/openjdk8:jdk8u272-b10-alpine
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
       com.wso2.docker.source="https://github.com/wso2/docker-apim/releases/tag/v2.6.0.10"
 

--- a/dockerfiles/centos/apim-analytics/dashboard/Dockerfile
+++ b/dockerfiles/centos/apim-analytics/dashboard/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to latest CentOS Docker image
-FROM centos:7
+FROM adoptopenjdk/openjdk8:jdk8u272-b10-centos
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
       com.wso2.docker.source="https://github.com/wso2/docker-apim/releases/tag/v2.6.0.10"
 
@@ -28,8 +28,6 @@ ARG USER_ID=802
 ARG USER_GROUP=wso2
 ARG USER_GROUP_ID=802
 ARG USER_HOME=/home/${USER}
-# set JDK configurations
-ARG JAVA_HOME=${USER_HOME}/java
 # build arguments for WSO2 product installation
 ARG WSO2_SERVER_NAME=wso2am-analytics
 ARG WSO2_SERVER_VERSION=2.6.0
@@ -62,14 +60,6 @@ RUN \
         unzip \
         wget \
     && rm -rf /var/cache/yum/*
-# install AdoptOpenJDK HotSpot
-RUN \
-    mkdir -p ${JAVA_HOME} \
-    && wget -O OpenJDK8U-jdk_x64_linux_hotspot.tar.gz https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u272-b10/OpenJDK8U-jdk_x64_linux_hotspot_8u272b10.tar.gz \
-    && echo "6f124b69d07d8d3edf39b9aa5c58473f63a380b686ddb73a5495e01d25c2939a  OpenJDK8U-jdk_x64_linux_hotspot.tar.gz" | sha256sum -c - \
-    && tar -xf OpenJDK8U-jdk_x64_linux_hotspot.tar.gz -C ${JAVA_HOME} --strip-components=1 \
-    && chown wso2carbon:wso2 -R ${JAVA_HOME} \
-    && rm -f OpenJDK8U-jdk_x64_linux_hotspot.tar.gz
 # add the WSO2 product distribution to user's home directory
 RUN \
     wget -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
@@ -84,9 +74,7 @@ USER ${USER_ID}
 WORKDIR ${USER_HOME}
 
 # set environment variables
-ENV JAVA_HOME=${JAVA_HOME} \
-    PATH=${JAVA_HOME}/bin:${PATH} \
-    WORKING_DIRECTORY=${USER_HOME} \
+ENV WORKING_DIRECTORY=${USER_HOME} \
     WSO2_SERVER_HOME=${WSO2_SERVER_HOME}
 
 # expose ports

--- a/dockerfiles/centos/apim-analytics/dashboard/Dockerfile
+++ b/dockerfiles/centos/apim-analytics/dashboard/Dockerfile
@@ -65,8 +65,8 @@ RUN \
 # install AdoptOpenJDK HotSpot
 RUN \
     mkdir -p ${JAVA_HOME} \
-    && wget -O OpenJDK8U-jdk_x64_linux_hotspot.tar.gz https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u222-b10/OpenJDK8U-jdk_x64_linux_hotspot_8u222b10.tar.gz \
-    && echo "37356281345b93feb4212e6267109b4409b55b06f107619dde4960e402bafa77  OpenJDK8U-jdk_x64_linux_hotspot.tar.gz" | sha256sum -c - \
+    && wget -O OpenJDK8U-jdk_x64_linux_hotspot.tar.gz https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u272-b10/OpenJDK8U-jdk_x64_linux_hotspot_8u272b10.tar.gz \
+    && echo "6f124b69d07d8d3edf39b9aa5c58473f63a380b686ddb73a5495e01d25c2939a  OpenJDK8U-jdk_x64_linux_hotspot.tar.gz" | sha256sum -c - \
     && tar -xf OpenJDK8U-jdk_x64_linux_hotspot.tar.gz -C ${JAVA_HOME} --strip-components=1 \
     && chown wso2carbon:wso2 -R ${JAVA_HOME} \
     && rm -f OpenJDK8U-jdk_x64_linux_hotspot.tar.gz

--- a/dockerfiles/centos/apim-analytics/worker/Dockerfile
+++ b/dockerfiles/centos/apim-analytics/worker/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to latest CentOS Docker image
-FROM centos:7
+FROM adoptopenjdk/openjdk8:jdk8u272-b10-centos
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
       com.wso2.docker.source="https://github.com/wso2/docker-apim/releases/tag/v2.6.0.10"
 
@@ -28,8 +28,6 @@ ARG USER_ID=802
 ARG USER_GROUP=wso2
 ARG USER_GROUP_ID=802
 ARG USER_HOME=/home/${USER}
-# set JDK configurations
-ARG JAVA_HOME=${USER_HOME}/java
 # build arguments for WSO2 product installation
 ARG WSO2_SERVER_NAME=wso2am-analytics
 ARG WSO2_SERVER_VERSION=2.6.0
@@ -62,14 +60,6 @@ RUN \
         unzip \
         wget \
     && rm -rf /var/cache/yum/*
-# install AdoptOpenJDK HotSpot
-RUN \
-    mkdir -p ${JAVA_HOME} \
-    && wget -O OpenJDK8U-jdk_x64_linux_hotspot.tar.gz https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u272-b10/OpenJDK8U-jdk_x64_linux_hotspot_8u272b10.tar.gz \
-    && echo "6f124b69d07d8d3edf39b9aa5c58473f63a380b686ddb73a5495e01d25c2939a  OpenJDK8U-jdk_x64_linux_hotspot.tar.gz" | sha256sum -c - \
-    && tar -xf OpenJDK8U-jdk_x64_linux_hotspot.tar.gz -C ${JAVA_HOME} --strip-components=1 \
-    && chown wso2carbon:wso2 -R ${JAVA_HOME} \
-    && rm -f OpenJDK8U-jdk_x64_linux_hotspot.tar.gz
 # add the WSO2 product distribution to user's home directory
 RUN \
     wget -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
@@ -84,9 +74,7 @@ USER ${USER_ID}
 WORKDIR ${USER_HOME}
 
 # set environment variables
-ENV JAVA_HOME=${JAVA_HOME} \
-    PATH=${JAVA_HOME}/bin:${PATH} \
-    WORKING_DIRECTORY=${USER_HOME} \
+ENV WORKING_DIRECTORY=${USER_HOME} \
     WSO2_SERVER_HOME=${WSO2_SERVER_HOME}
 
 # expose ports

--- a/dockerfiles/centos/apim-analytics/worker/Dockerfile
+++ b/dockerfiles/centos/apim-analytics/worker/Dockerfile
@@ -65,8 +65,8 @@ RUN \
 # install AdoptOpenJDK HotSpot
 RUN \
     mkdir -p ${JAVA_HOME} \
-    && wget -O OpenJDK8U-jdk_x64_linux_hotspot.tar.gz https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u222-b10/OpenJDK8U-jdk_x64_linux_hotspot_8u222b10.tar.gz \
-    && echo "37356281345b93feb4212e6267109b4409b55b06f107619dde4960e402bafa77  OpenJDK8U-jdk_x64_linux_hotspot.tar.gz" | sha256sum -c - \
+    && wget -O OpenJDK8U-jdk_x64_linux_hotspot.tar.gz https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u272-b10/OpenJDK8U-jdk_x64_linux_hotspot_8u272b10.tar.gz \
+    && echo "6f124b69d07d8d3edf39b9aa5c58473f63a380b686ddb73a5495e01d25c2939a  OpenJDK8U-jdk_x64_linux_hotspot.tar.gz" | sha256sum -c - \
     && tar -xf OpenJDK8U-jdk_x64_linux_hotspot.tar.gz -C ${JAVA_HOME} --strip-components=1 \
     && chown wso2carbon:wso2 -R ${JAVA_HOME} \
     && rm -f OpenJDK8U-jdk_x64_linux_hotspot.tar.gz

--- a/dockerfiles/centos/apim/Dockerfile
+++ b/dockerfiles/centos/apim/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to latest CentOS Docker image
-FROM centos:7
+FROM adoptopenjdk/openjdk8:jdk8u272-b10-centos
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
       com.wso2.docker.source="https://github.com/wso2/docker-apim/releases/tag/v2.6.0.10"
 
@@ -28,8 +28,6 @@ ARG USER_ID=802
 ARG USER_GROUP=wso2
 ARG USER_GROUP_ID=802
 ARG USER_HOME=/home/${USER}
-# set JDK configurations
-ARG JAVA_HOME=${USER_HOME}/java
 # build arguments for WSO2 product installation
 ARG WSO2_SERVER_NAME=wso2am
 ARG WSO2_SERVER_VERSION=2.6.0
@@ -62,14 +60,6 @@ RUN \
         unzip \
         wget \
     && rm -rf /var/cache/yum/*
-# install AdoptOpenJDK HotSpot
-RUN \
-    mkdir -p ${JAVA_HOME} \
-    && wget -O OpenJDK8U-jdk_x64_linux_hotspot.tar.gz https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u272-b10/OpenJDK8U-jdk_x64_linux_hotspot_8u272b10.tar.gz \
-    && echo "6f124b69d07d8d3edf39b9aa5c58473f63a380b686ddb73a5495e01d25c2939a  OpenJDK8U-jdk_x64_linux_hotspot.tar.gz" | sha256sum -c - \
-    && tar -xf OpenJDK8U-jdk_x64_linux_hotspot.tar.gz -C ${JAVA_HOME} --strip-components=1 \
-    && chown wso2carbon:wso2 -R ${JAVA_HOME} \
-    && rm -f OpenJDK8U-jdk_x64_linux_hotspot.tar.gz
 # add the WSO2 product distribution to user's home directory
 RUN \
     wget -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
@@ -87,9 +77,7 @@ USER ${USER_ID}
 WORKDIR ${USER_HOME}
 
 # set environment variables
-ENV JAVA_HOME=${JAVA_HOME} \
-    PATH=${JAVA_HOME}/bin:${PATH} \
-    WORKING_DIRECTORY=${USER_HOME} \
+ENV WORKING_DIRECTORY=${USER_HOME} \
     WSO2_SERVER_HOME=${WSO2_SERVER_HOME}
 
 # expose ports

--- a/dockerfiles/centos/apim/Dockerfile
+++ b/dockerfiles/centos/apim/Dockerfile
@@ -65,8 +65,8 @@ RUN \
 # install AdoptOpenJDK HotSpot
 RUN \
     mkdir -p ${JAVA_HOME} \
-    && wget -O OpenJDK8U-jdk_x64_linux_hotspot.tar.gz https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u222-b10/OpenJDK8U-jdk_x64_linux_hotspot_8u222b10.tar.gz \
-    && echo "37356281345b93feb4212e6267109b4409b55b06f107619dde4960e402bafa77  OpenJDK8U-jdk_x64_linux_hotspot.tar.gz" | sha256sum -c - \
+    && wget -O OpenJDK8U-jdk_x64_linux_hotspot.tar.gz https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u272-b10/OpenJDK8U-jdk_x64_linux_hotspot_8u272b10.tar.gz \
+    && echo "6f124b69d07d8d3edf39b9aa5c58473f63a380b686ddb73a5495e01d25c2939a  OpenJDK8U-jdk_x64_linux_hotspot.tar.gz" | sha256sum -c - \
     && tar -xf OpenJDK8U-jdk_x64_linux_hotspot.tar.gz -C ${JAVA_HOME} --strip-components=1 \
     && chown wso2carbon:wso2 -R ${JAVA_HOME} \
     && rm -f OpenJDK8U-jdk_x64_linux_hotspot.tar.gz

--- a/dockerfiles/centos/is-as-km/Dockerfile
+++ b/dockerfiles/centos/is-as-km/Dockerfile
@@ -67,8 +67,8 @@ RUN \
 # install AdoptOpenJDK HotSpot
 RUN \
     mkdir -p ${JAVA_HOME} \
-    && wget -O OpenJDK8U-jdk_x64_linux_hotspot.tar.gz https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u222-b10/OpenJDK8U-jdk_x64_linux_hotspot_8u222b10.tar.gz \
-    && echo "37356281345b93feb4212e6267109b4409b55b06f107619dde4960e402bafa77  OpenJDK8U-jdk_x64_linux_hotspot.tar.gz" | sha256sum -c - \
+    && wget -O OpenJDK8U-jdk_x64_linux_hotspot.tar.gz https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u272-b10/OpenJDK8U-jdk_x64_linux_hotspot_8u272b10.tar.gz \
+    && echo "6f124b69d07d8d3edf39b9aa5c58473f63a380b686ddb73a5495e01d25c2939a  OpenJDK8U-jdk_x64_linux_hotspot.tar.gz" | sha256sum -c - \
     && tar -xf OpenJDK8U-jdk_x64_linux_hotspot.tar.gz -C ${JAVA_HOME} --strip-components=1 \
     && chown wso2carbon:wso2 -R ${JAVA_HOME} \
     && rm -f OpenJDK8U-jdk_x64_linux_hotspot.tar.gz

--- a/dockerfiles/centos/is-as-km/Dockerfile
+++ b/dockerfiles/centos/is-as-km/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to latest CentOS Docker image
-FROM centos:7
+FROM adoptopenjdk/openjdk8:jdk8u272-b10-centos
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
       com.wso2.docker.source="https://github.com/wso2/docker-apim/releases/tag/v2.6.0.10"
 
@@ -28,8 +28,6 @@ ARG USER_ID=802
 ARG USER_GROUP=wso2
 ARG USER_GROUP_ID=802
 ARG USER_HOME=/home/${USER}
-# set JDK configurations
-ARG JAVA_HOME=${USER_HOME}/java
 # build arguments for WSO2 product installation
 ARG WSO2_SERVER_NAME=wso2is-km
 ARG WSO2_SERVER_VERSION=5.7.0
@@ -64,14 +62,6 @@ RUN \
         unzip \
         wget \
     && rm -rf /var/cache/yum/*
-# install AdoptOpenJDK HotSpot
-RUN \
-    mkdir -p ${JAVA_HOME} \
-    && wget -O OpenJDK8U-jdk_x64_linux_hotspot.tar.gz https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u272-b10/OpenJDK8U-jdk_x64_linux_hotspot_8u272b10.tar.gz \
-    && echo "6f124b69d07d8d3edf39b9aa5c58473f63a380b686ddb73a5495e01d25c2939a  OpenJDK8U-jdk_x64_linux_hotspot.tar.gz" | sha256sum -c - \
-    && tar -xf OpenJDK8U-jdk_x64_linux_hotspot.tar.gz -C ${JAVA_HOME} --strip-components=1 \
-    && chown wso2carbon:wso2 -R ${JAVA_HOME} \
-    && rm -f OpenJDK8U-jdk_x64_linux_hotspot.tar.gz
 # add the WSO2 product distribution to user's home directory
 RUN \
     wget -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
@@ -89,9 +79,7 @@ USER ${USER_ID}
 WORKDIR ${USER_HOME}
 
 # set environment variables
-ENV JAVA_HOME=${JAVA_HOME} \
-    PATH=${JAVA_HOME}/bin:${PATH} \
-    WORKING_DIRECTORY=${USER_HOME} \
+ENV WORKING_DIRECTORY=${USER_HOME} \
     WSO2_SERVER_HOME=${WSO2_SERVER_HOME}
 
 # expose ports

--- a/dockerfiles/ubuntu/apim-analytics/dashboard/Dockerfile
+++ b/dockerfiles/ubuntu/apim-analytics/dashboard/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
-FROM adoptopenjdk:8u222-b10-jdk-hotspot
+FROM adoptopenjdk:8u272-b10-jdk-hotspot
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
       com.wso2.docker.source="https://github.com/wso2/docker-apim/releases/tag/v2.6.0.10"
 

--- a/dockerfiles/ubuntu/apim-analytics/worker/Dockerfile
+++ b/dockerfiles/ubuntu/apim-analytics/worker/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
-FROM adoptopenjdk:8u222-b10-jdk-hotspot
+FROM adoptopenjdk:8u272-b10-jdk-hotspot
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
       com.wso2.docker.source="https://github.com/wso2/docker-apim/releases/tag/v2.6.0.10"
 

--- a/dockerfiles/ubuntu/apim/Dockerfile
+++ b/dockerfiles/ubuntu/apim/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
-FROM adoptopenjdk:8u222-b10-jdk-hotspot
+FROM adoptopenjdk:8u272-b10-jdk-hotspot
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
       com.wso2.docker.source="https://github.com/wso2/docker-apim/releases/tag/v2.6.0.10"
 

--- a/dockerfiles/ubuntu/is-as-km/Dockerfile
+++ b/dockerfiles/ubuntu/is-as-km/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
-FROM adoptopenjdk:8u222-b10-jdk-hotspot
+FROM adoptopenjdk:8u272-b10-jdk-hotspot
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
       com.wso2.docker.source="https://github.com/wso2/docker-apim/releases/tag/v2.6.0.10"
 


### PR DESCRIPTION
## Purpose
Update base image due to vulnerability in package `libcrypto1.1`
fix https://github.com/wso2/docker-apim/issues/386

### Trivy scan before update
```
$ ./trivy --exit-code 0 --severity HIGH --no-progress alpine-apim:${COMMIT}
2020-12-01T01:10:29.927Z	INFO	Need to update DB
2020-12-01T01:10:29.927Z	INFO	Downloading DB...
2020-12-01T01:10:54.472Z	INFO	Detecting Alpine vulnerabilities...
2020-12-01T01:10:54.473Z	INFO	Trivy skips scanning programming language libraries because no supported file was detected
alpine-apim:f7896a80 (alpine 3.10.2)
====================================
Total: 2 (HIGH: 2)
+--------------+------------------+----------+-------------------+---------------+--------------------------------+
|   LIBRARY    | VULNERABILITY ID | SEVERITY | INSTALLED VERSION | FIXED VERSION |             TITLE              |
+--------------+------------------+----------+-------------------+---------------+--------------------------------+
| libcrypto1.1 | CVE-2020-1967    | HIGH     | 1.1.1c-r0         | 1.1.1g-r0     | openssl: Segmentation fault in |
|              |                  |          |                   |               | SSL_check_chain causes denial  |
|              |                  |          |                   |               | of service                     |
+--------------+                  +          +                   +               +                                +
| libssl1.1    |                  |          |                   |               |                                |
|              |                  |          |                   |               |                                |
|              |                  |          |                   |               |                                |
+--------------+------------------+----------+-------------------+---------------+--------------------------------+
```

### Trivy scan after update

```
$ ./trivy --exit-code 0 --severity HIGH --no-progress alpine-apim:${COMMIT}
2020-12-01T01:25:36.430Z	INFO	Detecting Alpine vulnerabilities...
2020-12-01T01:25:36.432Z	INFO	Trivy skips scanning programming language libraries because no supported file was detected
alpine-apim:b6b51f16 (alpine 3.12.1)
====================================
Total: 0 (HIGH: 0)
```