### PR TITLE
[3.1.0] Upgrade AdoptOpenJDK 11 version to the latest version - 11.0.9_11

### DIFF
--- a/dockerfiles/alpine/apim-analytics/dashboard/Dockerfile
+++ b/dockerfiles/alpine/apim-analytics/dashboard/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Alpine Docker image
-FROM adoptopenjdk/openjdk11:jdk-11.0.6_10-alpine
+FROM adoptopenjdk/openjdk11:jdk-11.0.9_11.1-alpine
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
       com.wso2.docker.source="https://github.com/wso2/docker-apim/releases/tag/v3.1.0.4"
 

--- a/dockerfiles/alpine/apim-analytics/worker/Dockerfile
+++ b/dockerfiles/alpine/apim-analytics/worker/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Alpine Docker image
-FROM adoptopenjdk/openjdk11:jdk-11.0.6_10-alpine
+FROM adoptopenjdk/openjdk11:jdk-11.0.9_11.1-alpine
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
       com.wso2.docker.source="https://github.com/wso2/docker-apim/releases/tag/v3.1.0.4"
 

--- a/dockerfiles/alpine/apim/Dockerfile
+++ b/dockerfiles/alpine/apim/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Alpine Docker image
-FROM adoptopenjdk/openjdk11:jdk-11.0.6_10-alpine
+FROM adoptopenjdk/openjdk11:jdk-11.0.9_11.1-alpine
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
       com.wso2.docker.source="https://github.com/wso2/docker-apim/releases/tag/v3.1.0.4"
 

--- a/dockerfiles/alpine/is-as-km/Dockerfile
+++ b/dockerfiles/alpine/is-as-km/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Alpine Docker image
-FROM adoptopenjdk/openjdk11:jdk-11.0.6_10-alpine
+FROM adoptopenjdk/openjdk11:jdk-11.0.9_11.1-alpine
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
       com.wso2.docker.source="https://github.com/wso2/docker-apim/releases/tag/v3.1.0.4"
 

--- a/dockerfiles/centos/apim-analytics/dashboard/Dockerfile
+++ b/dockerfiles/centos/apim-analytics/dashboard/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK CentOS Docker image
-FROM adoptopenjdk/openjdk11:x86_64-centos-jdk-11.0.6_10
+FROM adoptopenjdk/openjdk11:jdk-11.0.9_11.1-centos
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
       com.wso2.docker.source="https://github.com/wso2/docker-apim/releases/tag/v3.1.0.4"
 

--- a/dockerfiles/centos/apim-analytics/worker/Dockerfile
+++ b/dockerfiles/centos/apim-analytics/worker/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK CentOS Docker image
-FROM adoptopenjdk/openjdk11:x86_64-centos-jdk-11.0.6_10
+FROM adoptopenjdk/openjdk11:jdk-11.0.9_11.1-centos
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
       com.wso2.docker.source="https://github.com/wso2/docker-apim/releases/tag/v3.1.0.4"
 

--- a/dockerfiles/centos/apim/Dockerfile
+++ b/dockerfiles/centos/apim/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK CentOS Docker image
-FROM adoptopenjdk/openjdk11:x86_64-centos-jdk-11.0.6_10
+FROM adoptopenjdk/openjdk11:jdk-11.0.9_11.1-centos
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
       com.wso2.docker.source="https://github.com/wso2/docker-apim/releases/tag/v3.1.0.4"
 

--- a/dockerfiles/centos/is-as-km/Dockerfile
+++ b/dockerfiles/centos/is-as-km/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK CentOS Docker image
-FROM adoptopenjdk/openjdk11:x86_64-centos-jdk-11.0.6_10
+FROM adoptopenjdk/openjdk11:jdk-11.0.9_11.1-centos
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
       com.wso2.docker.source="https://github.com/wso2/docker-apim/releases/tag/v3.1.0.4"
 

--- a/dockerfiles/ubuntu/apim-analytics/dashboard/Dockerfile
+++ b/dockerfiles/ubuntu/apim-analytics/dashboard/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
-FROM adoptopenjdk:11.0.6_10-jdk-hotspot-bionic
+FROM adoptopenjdk:11.0.9_11-jdk-hotspot-focal
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
       com.wso2.docker.source="https://github.com/wso2/docker-apim/releases/tag/v3.1.0.4"
 

--- a/dockerfiles/ubuntu/apim-analytics/worker/Dockerfile
+++ b/dockerfiles/ubuntu/apim-analytics/worker/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
-FROM adoptopenjdk:11.0.6_10-jdk-hotspot-bionic
+FROM adoptopenjdk:11.0.9_11-jdk-hotspot-focal
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
       com.wso2.docker.source="https://github.com/wso2/docker-apim/releases/tag/v3.1.0.4"
 

--- a/dockerfiles/ubuntu/apim/Dockerfile
+++ b/dockerfiles/ubuntu/apim/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
-FROM adoptopenjdk:11.0.6_10-jdk-hotspot-bionic
+FROM adoptopenjdk:11.0.9_11-jdk-hotspot-focal
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
       com.wso2.docker.source="https://github.com/wso2/docker-apim/releases/tag/v3.1.0.4"
 

--- a/dockerfiles/ubuntu/is-as-km/Dockerfile
+++ b/dockerfiles/ubuntu/is-as-km/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
-FROM adoptopenjdk:11.0.6_10-jdk-hotspot-bionic
+FROM adoptopenjdk:11.0.9_11-jdk-hotspot-focal
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
       com.wso2.docker.source="https://github.com/wso2/docker-apim/releases/tag/v3.1.0.4"
 


### PR DESCRIPTION
## Purpose
Update base image due to vulnerability in package `libcrypto1.1`, `libgcc`, `libssl1.1`, `libfreetype6`
fix #389

### Before update
```
alpine-apim:5880aec2 (alpine 3.11.5)
====================================
Total: 3 (HIGH: 3)
+--------------+------------------+----------+-------------------+---------------+--------------------------------+
|   LIBRARY    | VULNERABILITY ID | SEVERITY | INSTALLED VERSION | FIXED VERSION |             TITLE              |
+--------------+------------------+----------+-------------------+---------------+--------------------------------+
| libcrypto1.1 | CVE-2020-1967    | HIGH     | 1.1.1d-r3         | 1.1.1g-r0     | openssl: Segmentation fault in |
|              |                  |          |                   |               | SSL_check_chain causes denial  |
|              |                  |          |                   |               | of service                     |
+--------------+------------------+          +-------------------+---------------+--------------------------------+
| libgcc       | CVE-2019-15847   |          | 9.2.0-r4          | 9.3.0-r0      | gcc: POWER9 "DARN" RNG         |
|              |                  |          |                   |               | intrinsic produces repeated    |
|              |                  |          |                   |               | output                         |
+--------------+------------------+          +-------------------+---------------+--------------------------------+
| libssl1.1    | CVE-2020-1967    |          | 1.1.1d-r3         | 1.1.1g-r0     | openssl: Segmentation fault in |
|              |                  |          |                   |               | SSL_check_chain causes denial  |
|              |                  |          |                   |               | of service                     |
+--------------+------------------+----------+-------------------+---------------+--------------------------------+
```

```
centos-apim:5880aec2 (centos 7.9.2009)
======================================
Total: 0 (HIGH: 0)
```

```
ubuntu-apim:5880aec2 (ubuntu 18.04)
===================================
Total: 1 (HIGH: 1)
+--------------+------------------+----------+-------------------+------------------+--------------------------------+
|   LIBRARY    | VULNERABILITY ID | SEVERITY | INSTALLED VERSION |  FIXED VERSION   |             TITLE              |
+--------------+------------------+----------+-------------------+------------------+--------------------------------+
| libfreetype6 | CVE-2020-15999   | HIGH     | 2.8.1-2ubuntu2    | 2.8.1-2ubuntu2.1 | freetype: Heap-based buffer    |
|              |                  |          |                   |                  | overflow due to integer        |
|              |                  |          |                   |                  | truncation in Load_SBit_Png    |
+--------------+------------------+----------+-------------------+------------------+--------------------------------+
```

### After update
```
alpine-apim:f038ca30 (alpine 3.12.1)
====================================
Total: 0 (HIGH: 0)
```

```
centos-apim:f038ca30 (centos 7.9.2009)
======================================
Total: 0 (HIGH: 0)
```

```
ubuntu-apim:f038ca30 (ubuntu 20.04)
===================================
Total: 0 (HIGH: 0)
```