### PR TITLE
[2.6.x] Modify Dockerfile to Avoid Warning Logs in Centos apim and is-as-km Images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project 2.6.x per each release will be documented in
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## [v2.6.0.15] - 2021-07-19
+
+### Added
+- Create Java prefs directory to avoid warning logs printed by FileSystemPreferences class in centos apim and is-as-km images
+- Set JAVA_OPTS as an environment variable with values for java.util.prefs.systemRoot and java.util.prefs.userRoot
+
 ## [v2.6.0.12] - 2021-01-13
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ Docker Compose files have been created according to the most common API Manageme
 to quickly evaluate product features along side their co-operate API Management requirements. The Compose files make use of per profile
 Docker images of WSO2 API Manager, API Manager Analytics and WSO2 Identity Server as Key Manager, as well as MySQL.
 
-**Change log** from previous v2.6.0.9 release: [View Here](CHANGELOG.md)
+**Change log** from previous v2.6.0.14 release: [View Here](CHANGELOG.md)

--- a/dockerfiles/centos/apim/Dockerfile
+++ b/dockerfiles/centos/apim/Dockerfile
@@ -50,6 +50,14 @@ RUN \
     && useradd --system --create-home --home-dir ${USER_HOME} --no-log-init -g ${USER_GROUP_ID} -u ${USER_ID} ${USER} \
     && echo ${MOTD} > /etc/profile.d/motd.sh
 
+# create Java prefs dir
+# this is to avoid warning logs printed by FileSystemPreferences class
+RUN \
+    mkdir -p ${USER_HOME}/.java/.systemPrefs \
+    && mkdir -p ${USER_HOME}/.java/.userPrefs \
+    && chmod -R 755 ${USER_HOME}/.java \
+    && chown -R ${USER}:${USER_GROUP} ${USER_HOME}/.java
+
 # copy init script to user home
 COPY --chown=wso2carbon:wso2 docker-entrypoint.sh ${USER_HOME}/
 # install required packages
@@ -77,7 +85,8 @@ USER ${USER_ID}
 WORKDIR ${USER_HOME}
 
 # set environment variables
-ENV WORKING_DIRECTORY=${USER_HOME} \
+ENV JAVA_OPTS="-Djava.util.prefs.systemRoot=${USER_HOME}/.java -Djava.util.prefs.userRoot=${USER_HOME}/.java/.userPrefs" \
+    WORKING_DIRECTORY=${USER_HOME} \
     WSO2_SERVER_HOME=${WSO2_SERVER_HOME}
 
 # expose ports

--- a/dockerfiles/centos/is-as-km/Dockerfile
+++ b/dockerfiles/centos/is-as-km/Dockerfile
@@ -52,6 +52,14 @@ RUN \
     && useradd --system --create-home --home-dir ${USER_HOME} --no-log-init -g ${USER_GROUP_ID} -u ${USER_ID} ${USER} \
     && echo ${MOTD} > /etc/profile.d/motd.sh
 
+# create Java prefs dir
+# this is to avoid warning logs printed by FileSystemPreferences class
+RUN \
+    mkdir -p ${USER_HOME}/.java/.systemPrefs \
+    && mkdir -p ${USER_HOME}/.java/.userPrefs \
+    && chmod -R 755 ${USER_HOME}/.java \
+    && chown -R ${USER}:${USER_GROUP} ${USER_HOME}/.java
+
 # copy init script to user home
 COPY --chown=wso2carbon:wso2 docker-entrypoint.sh ${USER_HOME}/
 # install required packages
@@ -79,7 +87,8 @@ USER ${USER_ID}
 WORKDIR ${USER_HOME}
 
 # set environment variables
-ENV WORKING_DIRECTORY=${USER_HOME} \
+ENV JAVA_OPTS="-Djava.util.prefs.systemRoot=${USER_HOME}/.java -Djava.util.prefs.userRoot=${USER_HOME}/.java/.userPrefs" \
+    WORKING_DIRECTORY=${USER_HOME} \
     WSO2_SERVER_HOME=${WSO2_SERVER_HOME}
 
 # expose ports


### PR DESCRIPTION
## Purpose
- Modify Dockerfile to avoid warning logs in centos apim and is-as-km images

## Goals
- Avoid warning logs printed by FileSystemPreferences class

## Approach
- Create Java prefs directory to avoid warning logs printed by FileSystemPreferences class in centos apim and is-as-km images
- Set JAVA_OPTS as an environment variable with values for java.util.prefs.systemRoot and java.util.prefs.userRoot