### PR TITLE
Add support for APIM 4.1.0-beta in Docker images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ hs_err_pid*
 .idea/
 *.iml
 
+# macOS
+.DS_Store
+
 rat.txt
 
 # exclude everything

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update all Docker resources to support WSO2 API Manager version `4.1.0`.
 - Update all Docker Compose resources to supprt WSO2 API Manager version `4.1.0`.
 - Update Docker Compose resources for the deployment of WSO2 APIM with MI to support Micro Integrator version `4.1.0.0`.
-- Update IS extentions to latest version `1.2.10` and mount wso2carbon and client-truststore keystores with the latest wso2carbon certificate in Identity Server as Key Manager with Choreo Analytics deployment setup.
+- Update IS extentions to the [latest version](https://repo1.maven.org/maven2/org/wso2/km/ext/wso2is/distribution/1.4.2/) `1.4.2` and mount wso2carbon and client-truststore keystores with the latest wso2carbon certificate in Identity Server as Key Manager with Choreo Analytics deployment setup.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,29 +1,13 @@
 # Changelog
 
-All notable changes to Docker and Docker Compose resources for WSO2 API Management version `4.0.x` in each resource release, will be documented in this file.
+All notable changes to Docker and Docker Compose resources for WSO2 API Management version `4.1.x` in each resource release, will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [v4.0.0.4] - 2022-03-10
+## [v4.1.0.0] - 2022-03-23
 
 ### Changed
-- Use base OS images as opposed to AdoptOpenJDK images for each corresponding OS flavour (Alpine, CentOS, Ubuntu).
-- Use Temurin OpenJDK binaries to build OpenJDK on top of the base OS image.
-- Upgrade OpenJDK versions to the latest available versions of Temurin OpenJDK from Adoptium. 
-
-## [v4.0.0.1] - 2021-04-28
-
-### Added
-
-- Alpine, CentOS, and Ubuntu based Docker resources for WSO2 API Manager version `4.0.0`.
-- Docker Compose resources for the deployment of WSO2 API Manager `4.0.0` with Choreo Analytics support.
-- Docker Compose resources for the deployment of WSO2 API Manager `4.0.0` with Identity Server `5.11.0` as Key Manager and Choreo Analytics support.
-- Docker Compose resources for the deployment of WSO2 API Manager `4.0.0` with Micro Integrator `4.0.0`.
-
-### Changed
-
-- Upgrade MySQL version used in Docker Compose resources - `5.7.34`.
-
-### Removed
-
-- WSO2 API Manager Analytics Dashboard and Worker related Docker Compose resources.
+- Update all Docker resources to support WSO2 API Manager version `4.1.0`.
+- Update all Docker Compose resources to supprt WSO2 API Manager version `4.1.0`.
+- Update Docker Compose resources for the deployment of WSO2 APIM with MI to support Micro Integrator version `4.1.0.0`.
+- Update IS extentions to latest version `1.2.10` and mount wso2carbon and client-truststore keystores with the latest wso2carbon certificate in Identity Server as Key Manager with Choreo Analytics deployment setup.

--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ Docker Compose files have been created according to the most common API Manageme
 to quickly evaluate product features along side their co-operate API Management requirements. The Compose files make use of per profile
 Docker images of WSO2 API Manager, WSO2 Identity Server as Key Manager, and Micro Integrator as well as MySQL.
 
-**Change log** from previous v3.2.0.3 release: [View Here](https://github.com/wso2/docker-apim/blob/3.2.x/CHANGELOG.md)
+**Change log** from previous v4.0.0.4 release: [View Here](https://github.com/wso2/docker-apim/blob/4.0.x/CHANGELOG.md)

--- a/dockerfiles/centos/apim/Dockerfile
+++ b/dockerfiles/centos/apim/Dockerfile
@@ -65,7 +65,7 @@ RUN echo Verifying install ... \
     && echo Complete.
 
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-apim/releases/tag/v4.0.0.4"
+      com.wso2.docker.source="https://github.com/wso2/docker-apim/releases/tag/v4.1.0.0"
 
 # set Docker image build arguments
 # build arguments for user/group configurations
@@ -76,7 +76,7 @@ ARG USER_GROUP_ID=802
 ARG USER_HOME=/home/${USER}
 # build arguments for WSO2 product installation
 ARG WSO2_SERVER_NAME=wso2am
-ARG WSO2_SERVER_VERSION=4.0.0
+ARG WSO2_SERVER_VERSION=4.1.0-beta
 ARG WSO2_SERVER_REPOSITORY=product-apim
 ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
 ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}

--- a/dockerfiles/centos/apim/README.md
+++ b/dockerfiles/centos/apim/README.md
@@ -1,6 +1,6 @@
 # Dockerfile for WSO2 API Manager #
 
-This section defines the step-by-step instructions to build an [CentOS](https://hub.docker.com/_/centos/) Linux based Docker image for WSO2 API Manager 4.0.0.
+This section defines the step-by-step instructions to build an [CentOS](https://hub.docker.com/_/centos/) Linux based Docker image for WSO2 API Manager 4.1.0.
 
 ## Prerequisites
 
@@ -22,13 +22,13 @@ git clone https://github.com/wso2/docker-apim.git
 
 - Navigate to `<AM_DOCKERFILE_HOME>` directory. <br>
   Execute `docker build` command as shown below.
-    + `docker build -t wso2am:4.0.0-centos .`
+    + `docker build -t wso2am:4.1.0-centos .`
 
 > By default, the Docker image will prepackage the General Availability (GA) release version of the relevant WSO2 product.
 
 ##### 3. Running the Docker image.
 
-- `docker run -it -p 9443:9443 wso2am:4.0.0-centos`
+- `docker run -it -p 9443:9443 wso2am:4.1.0-centos`
 
 > Here, only port 9443 (HTTPS servlet transport) has been mapped to a Docker host port.
 You may map other container service ports, which have been exposed to Docker host ports, as desired.
@@ -47,7 +47,7 @@ As an example, steps required to change the port offset using `deployment.toml` 
 
 ##### 1. Stop the API Manager container if it's already running.
 
-In WSO2 API Manager version 4.0.0 product distribution, `deployment.toml` configuration file <br>
+In WSO2 API Manager version 4.1.0 product distribution, `deployment.toml` configuration file <br>
 can be found at `<DISTRIBUTION_HOME>/repository/conf`. Copy the file to some suitable location of the host machine, <br>
 referred to as `<SOURCE_CONFIGS>/deployment.toml` and change the offset value (`[server]->offset`) to 1.
 
@@ -63,10 +63,10 @@ chmod o+r <SOURCE_CONFIGS>/deployment.toml
 docker run \
 -p 9444:9444 \
 --volume <SOURCE_CONFIGS>/deployment.toml:<TARGET_CONFIGS>/deployment.toml \
-wso2am:4.0.0-centos
+wso2am:4.1.0-centos
 ```
 
-> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2am-4.0.0/repository/conf folder of the container.
+> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2am-4.1.0/repository/conf folder of the container.
 
 ## Docker command usage references
 

--- a/dockerfiles/ubuntu/apim/Dockerfile
+++ b/dockerfiles/ubuntu/apim/Dockerfile
@@ -76,7 +76,7 @@ RUN echo Verifying install ... \
     && echo Complete.
 
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-apim/releases/tag/v4.1.0"
+      com.wso2.docker.source="https://github.com/wso2/docker-apim/releases/tag/v4.1.0.0"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/ubuntu/apim/Dockerfile
+++ b/dockerfiles/ubuntu/apim/Dockerfile
@@ -76,7 +76,7 @@ RUN echo Verifying install ... \
     && echo Complete.
 
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-apim/releases/tag/v4.0.0.4"
+      com.wso2.docker.source="https://github.com/wso2/docker-apim/releases/tag/v4.1.0"
 
 # set Docker image build arguments
 # build arguments for user/group configurations
@@ -87,7 +87,7 @@ ARG USER_GROUP_ID=802
 ARG USER_HOME=/home/${USER}
 # build arguments for WSO2 product installation
 ARG WSO2_SERVER_NAME=wso2am
-ARG WSO2_SERVER_VERSION=4.0.0
+ARG WSO2_SERVER_VERSION=4.1.0-beta
 ARG WSO2_SERVER_REPOSITORY=product-apim
 ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
 ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}

--- a/dockerfiles/ubuntu/apim/README.md
+++ b/dockerfiles/ubuntu/apim/README.md
@@ -1,6 +1,6 @@
 # Dockerfile for WSO2 API Manager #
 
-This section defines the step-by-step instructions to build an [Ubuntu](https://hub.docker.com/_/ubuntu/) Linux based Docker image for WSO2 API Manager 4.0.0.
+This section defines the step-by-step instructions to build an [Ubuntu](https://hub.docker.com/_/ubuntu/) Linux based Docker image for WSO2 API Manager 4.1.0.
 
 ## Prerequisites
 
@@ -21,13 +21,13 @@ git clone https://github.com/wso2/docker-apim.git
 
 - Navigate to `<AM_DOCKERFILE_HOME>` directory. <br>
   Execute `docker build` command as shown below.
-    + `docker build -t wso2am:4.0.0 .`
+    + `docker build -t wso2am:4.1.0`
     
 > By default, the Docker image will prepackage the General Availability (GA) release version of the relevant WSO2 product.
     
 ##### 3. Running the Docker image.
 
-- `docker run -it -p 9443:9443 wso2am:4.0.0`
+- `docker run -it -p 9443:9443 wso2am:4.1.0`
 
 > Here, only port 9443 (HTTPS servlet transport) has been mapped to a Docker host port.
 You may map other container service ports, which have been exposed to Docker host ports, as desired.
@@ -46,7 +46,7 @@ As an example, steps required to change the port offset using `deployment.toml` 
 
 ##### 1. Stop the API Manager container if it's already running.
 
-In WSO2 API Manager version 4.0.0 product distribution, `deployment.toml` configuration file <br>
+In WSO2 API Manager version 4.1.0 product distribution, `deployment.toml` configuration file <br>
 can be found at `<DISTRIBUTION_HOME>/repository/conf`. Copy the file to some suitable location of the host machine, <br>
 referred to as `<SOURCE_CONFIGS>/deployment.toml` and change the offset value (`[server]->offset`) to 1.
 
@@ -62,10 +62,10 @@ chmod o+r <SOURCE_CONFIGS>/deployment.toml
 docker run \
 -p 9444:9444 \
 --volume <SOURCE_CONFIGS>/deployment.toml:<TARGET_CONFIGS>/deployment.toml \
-wso2am:4.0.0
+wso2am:4.1.0
 ```
 
-> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2am-4.0.0/repository/conf folder of the container.
+> In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2am-4.1.0/repository/conf folder of the container.
 
 ## Docker command usage references
 


### PR DESCRIPTION
## Purpose
To support APIM 4.1.0-beta in dockerfiles.

## Related PRs
https://github.com/wso2/docker-apim/pull/453
https://github.com/wso2/docker-apim/pull/454