### PR TITLE
[4.1.x] Update Readmes with public image and arm64 support

### DIFF
--- a/docker-compose/apim-is-as-km-with-analytics/README.md
+++ b/docker-compose/apim-is-as-km-with-analytics/README.md
@@ -7,6 +7,8 @@
  * In order to use Docker images with WSO2 updates, you need an active WSO2 subscription.
    Otherwise, you can proceed with Docker images available at [DockerHub](https://hub.docker.com/u/wso2/), which are created using GA releases.<br><br>
  * If you wish to run the Docker Compose setup using Docker images built locally, build Docker images using Docker resources available from [here](../../dockerfiles/) and remove the `docker.wso2.com/` prefix from the `image` name in the `docker-compose.yml`. <br><br>
+* If you don't have a valid WSO2 Subscription, you can replace the images in [dockerfiles](../apim-is-as-km-with-analytics/dockerfiles/) with the [public image](https://hub.docker.com/repository/docker/wso2/wso2am) (`wso2/wso2am:4.1.0`). <br><br>
+* If you are trying this out on Apple Silicon (with M1), use the public image that supports arm64 architecture (`wso2/wso2am:4.1.0-multiarch`). <br><br>
 
 ## Quick Start Guide
 

--- a/docker-compose/apim-with-analytics/README.md
+++ b/docker-compose/apim-with-analytics/README.md
@@ -8,6 +8,8 @@
    Otherwise, you can proceed with Docker images available at [DockerHub](https://hub.docker.com/u/wso2/), which are created using GA releases.<br><br>
  * If you wish to run the Docker Compose setup using Docker images built locally, build Docker images using Docker resources
    available from [here](../../dockerfiles/) and remove the `docker.wso2.com/` prefix from the base image (i.e. `FROM` instruction) in the [Dockerfiles](dockerfiles). <br><br>
+* If you don't have a valid WSO2 Subscription, you can replace the images in [dockerfiles](../apim-with-analytics/dockerfiles/) with the [public image](https://hub.docker.com/repository/docker/wso2/wso2am) (`wso2/wso2am:4.1.0`). <br><br>
+* If you are trying this out on Apple Silicon (with M1), use the public image that supports arm64 architecture (`wso2/wso2am:4.1.0-multiarch`). <br><br>
 
 ## Quick Start Guide
 

--- a/docker-compose/apim-with-mi/README.md
+++ b/docker-compose/apim-with-mi/README.md
@@ -7,6 +7,8 @@
  * In order to use Docker images with WSO2 updates, you need an active WSO2 subscription.
    Otherwise, you can proceed with Docker images available at [DockerHub](https://hub.docker.com/u/wso2/), which are created using GA releases.<br><br>
  * If you wish to run the Docker Compose setup using Docker images built locally, build Docker images using Docker resources available from [here](../../dockerfiles/) and remove the `docker.wso2.com/` prefix from the `image` name in the `docker-compose.yml`. <br><br>
+* If you don't have a valid WSO2 Subscription, you can replace the images in [dockerfiles](../apim-with-mi/dockerfiles/) with the [public image](https://hub.docker.com/repository/docker/wso2/wso2am) (`wso2/wso2am:4.1.0`). <br><br>
+* If you are trying this out on Apple Silicon (with M1), use the public image that supports arm64 architecture (`wso2/wso2am:4.1.0-multiarch`). <br><br>
 
 ## Quick Start Guide
 


### PR DESCRIPTION
## Purpose
This PR updates the docker-compose readme files on the possibility of using public images and `arm64` supported images for M1  Macbooks