### PR TITLE
[3.2.x] Bump Ubuntu version to 22.04 and Alpine version to 3.19.0

### DIFF
--- a/dockerfiles/alpine/apim/Dockerfile
+++ b/dockerfiles/alpine/apim/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to Alpine Docker image
-FROM alpine:3.15
+FROM alpine:3.19.0
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/dockerfiles/ubuntu/apim/Dockerfile
+++ b/dockerfiles/ubuntu/apim/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to Ubuntu Focal Docker image
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 


### PR DESCRIPTION
## Purpose
This PR bumps Ubuntu version to 22.04 and Alpine version to 3.19.0 in APIM 3.2.0 docker images.

Fixes https://github.com/wso2/api-manager/issues/2394