### PR TITLE
Bump Alpine version to 3.19.0 of APIM

### DIFF
--- a/dockerfiles/alpine/apim/Dockerfile
+++ b/dockerfiles/alpine/apim/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to Alpine Docker image
-FROM alpine:3.17.2
+FROM alpine:3.19.0
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 


### PR DESCRIPTION
## Purpose
This PR bumps Alpine version to 3.19.0 in APIM docker image.

Fixes https://github.com/wso2/api-manager/issues/2394