### PR TITLE
[4.2.x]  Update Alpine base image

### DIFF
--- a/dockerfiles/alpine/apim/Dockerfile
+++ b/dockerfiles/alpine/apim/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to Alpine Docker image
-FROM alpine:3.17.2
+FROM alpine:3.19.2
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/dockerfiles/jdk11/alpine/apim/Dockerfile
+++ b/dockerfiles/jdk11/alpine/apim/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to Alpine Docker image
-FROM alpine:3.17.2
+FROM alpine:3.19.2
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 


### PR DESCRIPTION
## Purpose
> Update the Alpine base image from version 3.17.2 to 3.19.2.
> Related issue: https://github.com/wso2-enterprise/wso2-apim-internal/issues/6745

## Approach
> Update the Alpine base image to version 3.19.2 in the Dockerfiles for both JDK 17 and JDK 11.
