### PR TITLE
Remove unnecessary copy of synapse-configs in Dockerfile

### DIFF
--- a/dockerfiles/alpine/apim-tm/Dockerfile
+++ b/dockerfiles/alpine/apim-tm/Dockerfile
@@ -101,7 +101,6 @@ RUN \
     && mkdir ${USER_HOME}/wso2-tmp \
     && bash -c 'mkdir -p ${USER_HOME}/solr/{indexed-data,database}' \
     && chown wso2carbon:wso2 -R ${USER_HOME}/solr \
-    && cp -r ${WSO2_SERVER_HOME}/repository/deployment/server/synapse-configs ${USER_HOME}/wso2-tmp \
     && cp -r ${WSO2_SERVER_HOME}/repository/deployment/server/executionplans ${USER_HOME}/wso2-tmp \
     && rm -f ${WSO2_SERVER}.zip
 


### PR DESCRIPTION
This pull request will fix a bug in the Alpine image build process. The change removes the copying of the `synapse-configs` directory to the temporary directory during the Docker image build process.

* [`dockerfiles/alpine/apim-tm/Dockerfile`](diffhunk://#diff-2e45e6eaf44886b21b4b581d5d5d40fcd7ea1f4936b5b73b3a94169060088d76L104): Removed the line that copies the `synapse-configs` directory to the `wso2-tmp` directory.