### PR TITLE
Update healthcheck commands in Docker Compose for improved reliability

### DIFF
--- a/docker-compose/apim-is-as-km-with-analytics/docker-compose.yml
+++ b/docker-compose/apim-is-as-km-with-analytics/docker-compose.yml
@@ -29,7 +29,7 @@ services:
         hard: 40000
     command: [--ssl=0]
     healthcheck:
-      test: ["CMD", "mysqladmin" ,"ping", "-uroot", "-proot"]
+      test: ["CMD", "sh", "-c", "mysqladmin ping -uroot -proot && [ -f /var/lib/mysql/initialization-complete.flag ]"]
       interval: 30s
       timeout: 60s
       retries: 5
@@ -37,7 +37,7 @@ services:
   is-as-km:
     build: ./dockerfiles/is-as-km
     healthcheck:
-      test: ["CMD", "sh", "-c", "mysqladmin ping -uroot -proot && [ -f /var/lib/mysql/initialization-complete.flag ]"]
+      test: ["CMD", "curl", "--fail", "http://localhost:9444/api/health-check/v1.0/health"]
       interval: 10s
       start_period: 180s
       retries: 20


### PR DESCRIPTION
This pull request includes updates to the health check commands in the `docker-compose.yml` file for the `apim-is-as-km-with-analytics` service. The most important changes include modifying the health check tests for the `mysql` and `is-as-km` services.

Health check updates:

* [`docker-compose/apim-is-as-km-with-analytics/docker-compose.yml`](diffhunk://#diff-ce3ef27148da677ff609d287bf1a364fc4c2565ea08148046abf0a0d430897e7L32-R40): Updated the `mysql` service health check to ensure the initialization is complete by checking for a specific flag file.
* [`docker-compose/apim-is-as-km-with-analytics/docker-compose.yml`](diffhunk://#diff-ce3ef27148da677ff609d287bf1a364fc4c2565ea08148046abf0a0d430897e7L32-R40): Changed the `is-as-km` service health check to use a curl command to check the health endpoint.