### PR TITLE
Update user group argument in Dockerfile for APIM TM

### DIFF
--- a/dockerfiles/alpine/apim-tm/Dockerfile
+++ b/dockerfiles/alpine/apim-tm/Dockerfile
@@ -65,7 +65,7 @@ LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>"  \
 # build arguments for user/group configurations
 ARG USER=wso2carbon
 ARG USER_ID=10001
-ARG USER_GROUP=wso2
+ARG USER_GROUP=wso2-tm
 ARG USER_GROUP_ID=10001
 ARG USER_HOME=/home/${USER}
 # build arguments for WSO2 product installation


### PR DESCRIPTION
This pull request includes a change to the `dockerfiles/alpine/apim-tm/Dockerfile` file. The change updates the user group configuration.

* [`dockerfiles/alpine/apim-tm/Dockerfile`](diffhunk://#diff-2e45e6eaf44886b21b4b581d5d5d40fcd7ea1f4936b5b73b3a94169060088d76L68-R68): Changed the `USER_GROUP` argument from `wso2` to `wso2-tm` for user/group configurations.