### PR TITLE
Update entrypoint scripts to use gateway.sh instead of api-gateway.sh

### DIFF
--- a/dockerfiles/alpine/apim-universal-gw/docker-entrypoint.sh
+++ b/dockerfiles/alpine/apim-universal-gw/docker-entrypoint.sh
@@ -56,4 +56,4 @@ test -d ${artifact_volume} && [[ "$(ls -A ${artifact_volume})" ]] && cp -RL ${ar
 
 # start WSO2 Carbon server
 echo "Start WSO2 Carbon server" >&2
-sh ${WSO2_SERVER_HOME}/bin/api-gateway.sh "$@"
+sh ${WSO2_SERVER_HOME}/bin/gateway.sh "$@"

--- a/dockerfiles/rocky/apim-universal-gw/docker-entrypoint.sh
+++ b/dockerfiles/rocky/apim-universal-gw/docker-entrypoint.sh
@@ -56,4 +56,4 @@ test -d ${artifact_volume} && [[ "$(ls -A ${artifact_volume})" ]] && cp -RL ${ar
 
 # start WSO2 Carbon server
 echo "Start WSO2 Carbon server" >&2
-sh ${WSO2_SERVER_HOME}/bin/api-gateway.sh "$@"
+sh ${WSO2_SERVER_HOME}/bin/gateway.sh "$@"

--- a/dockerfiles/ubuntu/apim-universal-gw/docker-entrypoint.sh
+++ b/dockerfiles/ubuntu/apim-universal-gw/docker-entrypoint.sh
@@ -56,4 +56,4 @@ test -d ${artifact_volume} && [[ "$(ls -A ${artifact_volume})" ]] && cp -RL ${ar
 
 # start WSO2 Carbon server
 echo "Start WSO2 Carbon server" >&2
-sh ${WSO2_SERVER_HOME}/bin/api-gateway.sh "$@"
+sh ${WSO2_SERVER_HOME}/bin/gateway.sh "$@"


### PR DESCRIPTION
This pull request includes changes to the `docker-entrypoint.sh` script files for three different Docker environments to update the command used to start the WSO2 Carbon server.

Changes to start WSO2 Carbon server:

* [`dockerfiles/alpine/apim-universal-gw/docker-entrypoint.sh`](diffhunk://#diff-00195cd6c552920f43d9214eedd6db4dd688e79dd78af84527cbb5f184992469L59-R59): Updated the command from `api-gateway.sh` to `gateway.sh` to start the WSO2 Carbon server.
* [`dockerfiles/rocky/apim-universal-gw/docker-entrypoint.sh`](diffhunk://#diff-00195cd6c552920f43d9214eedd6db4dd688e79dd78af84527cbb5f184992469L59-R59): Updated the command from `api-gateway.sh` to `gateway.sh` to start the WSO2 Carbon server.
* [`dockerfiles/ubuntu/apim-universal-gw/docker-entrypoint.sh`](diffhunk://#diff-00195cd6c552920f43d9214eedd6db4dd688e79dd78af84527cbb5f184992469L59-R59): Updated the command from `api-gateway.sh` to `gateway.sh` to start the WSO2 Carbon server.