### PR TITLE
Fix: Health endpoint issue in Docker compose

### DIFF
--- a/docker-compose/apim-is-as-km-with-analytics/README.md
+++ b/docker-compose/apim-is-as-km-with-analytics/README.md
@@ -51,7 +51,7 @@
     [apim.analytics]
     enable = true
     config_endpoint = "https://analytics-event-auth.choreo.dev/auth/v1"
-    auth_token = "<on-prem-key>"
+    auth_token = "on-prem-key"
     ```
 
 7. Execute following Docker Compose command to start the deployment.

--- a/docker-compose/apim-is-as-km-with-analytics/conf/apim/repository/conf/deployment.toml
+++ b/docker-compose/apim-is-as-km-with-analytics/conf/apim/repository/conf/deployment.toml
@@ -106,7 +106,7 @@ gateway_labels =["Default"]
 [apim.analytics]	
 enable = true	
 config_endpoint = "https://analytics-event-auth.choreo.dev/auth/v1"	
-auth_token = "<on-prem-key>"
+auth_token = "on-prem-key"
 
 [apim.ai]
 enable = true

--- a/docker-compose/apim-is-as-km-with-analytics/docker-compose.yml
+++ b/docker-compose/apim-is-as-km-with-analytics/docker-compose.yml
@@ -37,7 +37,7 @@ services:
   is-as-km:
     build: ./dockerfiles/is-as-km
     healthcheck:
-      test: ["CMD", "curl", "--fail", "http://localhost:9444/api/health-check/v1.0/health"]
+      test: ["CMD", "curl", "--fail", "https://localhost:9444/api/health-check/v1.0/health"]
       interval: 10s
       start_period: 180s
       retries: 20

--- a/docker-compose/apim-with-analytics/README.md
+++ b/docker-compose/apim-with-analytics/README.md
@@ -43,7 +43,7 @@
     [apim.analytics]
     enable = true
     config_endpoint = "https://analytics-event-auth.choreo.dev/auth/v1"
-    auth_token = "<on-prem-key>"
+    auth_token = "on-prem-key"
     ```
 
 6. Execute following Docker Compose command to start the deployment.

--- a/docker-compose/apim-with-analytics/conf/apim/repository/conf/deployment.toml
+++ b/docker-compose/apim-with-analytics/conf/apim/repository/conf/deployment.toml
@@ -106,7 +106,7 @@ gateway_labels =["Default"]
 [apim.analytics]	
 enable = true	
 config_endpoint = "https://analytics-event-auth.choreo.dev/auth/v1"	
-auth_token = "<on-prem-key>"
+auth_token = "on-prem-key"
 
 [apim.ai]
 enable = true


### PR DESCRIPTION
## Purpose  
- Fix the Health endpoint issue in Docker Compose.  
- If the user does not specify `apim.analytics.auth-token`, startup will fail due to an XML issue.  

## Goals  
- Docker Compose files should work with default values without requiring any additional configuration.  

## Approach  
- Update the Health endpoint.  
- Remove `<>` from the `deployment.toml` file.  
