### PR TITLE
Change default Docker image tag in workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -25,7 +25,7 @@ on:
       tag:
         description: 'Docker image tag'
         required: true
-        default: 'latest'
+        default: 'wso2/wso2am:latest'
       product_version:
         description: 'Product version'
         required: true


### PR DESCRIPTION
This pull request makes a minor update to the default Docker image tag in the GitHub Actions workflow configuration.

* Changed the default value of the `tag` input in `.github/workflows/docker-publish.yml` from `'latest'` to `'wso2/wso2am:latest'`, ensuring published images are tagged with the full repository and image name by default.