### PR TITLE
Update Docker image references from docker.wso2.com to registry.wso2.com

### DIFF
--- a/docker-compose/apim-is-as-km-with-analytics/README.md
+++ b/docker-compose/apim-is-as-km-with-analytics/README.md
@@ -5,7 +5,7 @@
  * Install [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git), [Docker](https://www.docker.com/get-docker) and [Docker Compose](https://docs.docker.com/compose/install/#install-compose)
    in order to run the steps provided in following Quick start guide. <br><br>
  * In order to use Docker images with WSO2 updates, you need an active WSO2 subscription.
-   If you don't have a valid WSO2 Subscription, you need to build Docker images by source. Build Docker images using Docker resources available in [here](../../dockerfiles/) and replace the `docker.wso2.com/` prefix from the `image` name in the `docker-compose.yml`. <br><br>
+   If you don't have a valid WSO2 Subscription, you need to build Docker images by source. Build Docker images using Docker resources available in [here](../../dockerfiles/) and replace the `registry.wso2.com/` prefix from the `image` name in the `docker-compose.yml`. <br><br>
 * If you are trying this out on Apple Silicon (with M1), build images that supports arm64 architecture according to the instructions in [README](../../dockerfiles/ubuntu/apim/README.md). <br><br>
 
 ## Quick Start Guide
@@ -13,7 +13,7 @@
 1. Login to WSO2's Private Docker Registry via Docker client. When prompted, enter the username and password of your WSO2 Subscription.
 
    ```
-   docker login docker.wso2.com
+   docker login registry.wso2.com
    ```
 
 2. Clone WSO2 API Management Docker and Docker Compose resource Git repository.

--- a/docker-compose/apim-is-as-km-with-analytics/dockerfiles/apim/Dockerfile
+++ b/docker-compose/apim-is-as-km-with-analytics/dockerfiles/apim/Dockerfile
@@ -18,7 +18,7 @@
 
 # set base Docker image to WSO2 API Manager Docker image with latest WSO2 Updates
 
-FROM docker.wso2.com/wso2am:4.6.0.0
+FROM registry.wso2.com/wso2-apim/am:4.6.0.0
 
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>"
 

--- a/docker-compose/apim-is-as-km-with-analytics/dockerfiles/is-as-km/Dockerfile
+++ b/docker-compose/apim-is-as-km-with-analytics/dockerfiles/is-as-km/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to WSO2 API Manager Docker image with latest WSO2 Updates
-FROM docker.wso2.com/wso2is:6.1.0.0
+FROM registry.wso2.com/wso2-is/is:6.1.0.0
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>"
 
 ARG MYSQL_CONNECTOR_VERSION=8.0.30

--- a/docker-compose/apim-with-analytics/README.md
+++ b/docker-compose/apim-with-analytics/README.md
@@ -5,7 +5,7 @@
  * Install [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git), [Docker](https://www.docker.com/get-docker) and [Docker Compose](https://docs.docker.com/compose/install/#install-compose)
    in order to run the steps provided in following Quick start guide. <br><br>
  * In order to use Docker images with WSO2 updates, you need an active WSO2 subscription.
-   If you don't have a valid WSO2 Subscription, you need to build Docker images by source. Build Docker images using Docker resources available in [here](../../dockerfiles/) and replace the `docker.wso2.com/` prefix from the `image` name in the `docker-compose.yml`. <br><br>
+   If you don't have a valid WSO2 Subscription, you need to build Docker images by source. Build Docker images using Docker resources available in [here](../../dockerfiles/) and replace the `registry.wso2.com/` prefix from the `image` name in the `docker-compose.yml`. <br><br>
 * If you are trying this out on Apple Silicon (with M1), build images that supports arm64 architecture according to the instructions in [README](../../dockerfiles/ubuntu/apim/README.md). <br><br>
 
 ## Quick Start Guide
@@ -13,7 +13,7 @@
 1. Login to WSO2's Private Docker Registry via Docker client. When prompted, enter the username and password of your WSO2 Subscription.
 
    ```
-   docker login docker.wso2.com
+   docker login registry.wso2.com
    ```
 
 2. Clone WSO2 API Management Docker and Docker Compose resource Git repository.

--- a/docker-compose/apim-with-analytics/dockerfiles/apim/Dockerfile
+++ b/docker-compose/apim-with-analytics/dockerfiles/apim/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to WSO2 API Manager Docker image with latest WSO2 Updates
-FROM docker.wso2.com/wso2am:4.6.0.0
+FROM registry.wso2.com/wso2-apim/am:4.6.0.0
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>"
 
 # build arguments for external artifacts

--- a/docker-compose/apim-with-mi/README.md
+++ b/docker-compose/apim-with-mi/README.md
@@ -5,7 +5,7 @@
  * Install [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git), [Docker](https://www.docker.com/get-docker) and [Docker Compose](https://docs.docker.com/compose/install/#install-compose)
    in order to run the steps provided in following Quick start guide. <br><br>
  * In order to use Docker images with WSO2 updates, you need an active WSO2 subscription.
-   If you don't have a valid WSO2 Subscription, you need to build Docker images by source. Build Docker images using Docker resources available in [here](../../dockerfiles/) and replace the `docker.wso2.com/` prefix from the `image` name in the `docker-compose.yml`. <br><br>
+   If you don't have a valid WSO2 Subscription, you need to build Docker images by source. Build Docker images using Docker resources available in [here](../../dockerfiles/) and replace the `registry.wso2.com/` prefix from the `image` name in the `docker-compose.yml`. <br><br>
 * If you are trying this out on Apple Silicon (with M1), build images that supports arm64 architecture according to the instructions in [README](../../dockerfiles/ubuntu/apim/README.md). <br><br>
 
 ## Quick Start Guide
@@ -13,7 +13,7 @@
 1. Login to WSO2's Private Docker Registry via Docker client. When prompted, enter the username and password of your WSO2 Subscription.
 
    ```
-   docker login docker.wso2.com
+   docker login registry.wso2.com
    ```
 
 2. Clone WSO2 API Management Docker and Docker Compose resource Git repository.

--- a/docker-compose/apim-with-mi/dockerfiles/apim/Dockerfile
+++ b/docker-compose/apim-with-mi/dockerfiles/apim/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to WSO2 API Manager Docker image with latest WSO2 Updates
-FROM registry.wso2.com/wso2am:4.6.0.0
+FROM registry.wso2.com/wso2-apim/am:4.6.0.0
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>"
 
 # build arguments for external artifacts

--- a/docker-compose/apim-with-mi/dockerfiles/apim/Dockerfile
+++ b/docker-compose/apim-with-mi/dockerfiles/apim/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to WSO2 API Manager Docker image with latest WSO2 Updates
-FROM docker.wso2.com/wso2am:4.6.0.0
+FROM registry.wso2.com/wso2am:4.6.0.0
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>"
 
 # build arguments for external artifacts

--- a/docker-compose/apim-with-mi/dockerfiles/mi/Dockerfile
+++ b/docker-compose/apim-with-mi/dockerfiles/mi/Dockerfile
@@ -16,7 +16,7 @@
 #
 # ------------------------------------------------------------------------
 
-FROM registry.wso2.com/wso2mi:4.5.0.0
+FROM registry.wso2.com/wso2-integrator/mi:4.5.0.0
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>"
 
 # copy CAR files to the MI server home

--- a/docker-compose/apim-with-mi/dockerfiles/mi/Dockerfile
+++ b/docker-compose/apim-with-mi/dockerfiles/mi/Dockerfile
@@ -16,7 +16,7 @@
 #
 # ------------------------------------------------------------------------
 
-FROM docker.wso2.com/wso2mi:4.5.0.0
+FROM registry.wso2.com/wso2mi:4.5.0.0
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>"
 
 # copy CAR files to the MI server home

--- a/dockerfiles/alpine/apim-acp/README.md
+++ b/dockerfiles/alpine/apim-acp/README.md
@@ -80,7 +80,7 @@ wso2am-acp:4.7.0-alpine
 
 ## WSO2 Private Docker images
 
-If you have a valid WSO2 subscription you can have access to WSO2 private Docker images. These images will get updated frequently with bug fixes, security fixes and new improvements. To view available images visit [WSO2 Docker Repositories](https://docker.wso2.com/)
+If you have a valid WSO2 subscription you can have access to WSO2 private Docker images. These images will get updated frequently with bug fixes, security fixes and new improvements. To view available images visit [WSO2 Docker Repositories](https://registry.wso2.com/)
 
 ## Docker command usage references
 

--- a/dockerfiles/alpine/apim-tm/README.md
+++ b/dockerfiles/alpine/apim-tm/README.md
@@ -81,7 +81,7 @@ wso2am-tm:4.7.0-alpine
 
 ## WSO2 Private Docker images
 
-If you have a valid WSO2 subscription you can have access to WSO2 private Docker images. These images will get updated frequently with bug fixes, security fixes and new improvements. To view available images visit [WSO2 Docker Repositories](https://docker.wso2.com/)
+If you have a valid WSO2 subscription you can have access to WSO2 private Docker images. These images will get updated frequently with bug fixes, security fixes and new improvements. To view available images visit [WSO2 Docker Repositories](https://registry.wso2.com/)
 
 ## Docker command usage references
 

--- a/dockerfiles/alpine/apim-universal-gw/README.md
+++ b/dockerfiles/alpine/apim-universal-gw/README.md
@@ -81,7 +81,7 @@ wso2am-universal-gw:4.7.0-alpine
 
 ## WSO2 Private Docker images
 
-If you have a valid WSO2 subscription you can have access to WSO2 private Docker images. These images will get updated frequently with bug fixes, security fixes and new improvements. To view available images visit [WSO2 Docker Repositories](https://docker.wso2.com/)
+If you have a valid WSO2 subscription you can have access to WSO2 private Docker images. These images will get updated frequently with bug fixes, security fixes and new improvements. To view available images visit [WSO2 Docker Repositories](https://registry.wso2.com/)
 
 ## Docker command usage references
 

--- a/dockerfiles/alpine/apim/README.md
+++ b/dockerfiles/alpine/apim/README.md
@@ -81,7 +81,7 @@ wso2am:4.7.0-alpine
 
 ## WSO2 Private Docker images
 
-If you have a valid WSO2 subscription you can have access to WSO2 private Docker images. These images will get updated frequently with bug fixes, security fixes and new improvements. To view available images visit [WSO2 Docker Repositories](https://docker.wso2.com/)
+If you have a valid WSO2 subscription you can have access to WSO2 private Docker images. These images will get updated frequently with bug fixes, security fixes and new improvements. To view available images visit [WSO2 Docker Repositories](https://registry.wso2.com/)
 
 ## Docker command usage references
 

--- a/dockerfiles/rocky/apim-acp/README.md
+++ b/dockerfiles/rocky/apim-acp/README.md
@@ -117,7 +117,7 @@ docker run -it -p 9443:9443 -p 8243:8243 <DOCKER_USERNAME>/wso2am-acp:4.7.0-rock
 
 ## WSO2 Private Docker images
 
-If you have a valid WSO2 subscription you can have access to WSO2 private Docker images. These images will get updated frequently with bug fixes, security fixes and new improvements. To view available images visit [WSO2 Docker Repositories](https://docker.wso2.com/)
+If you have a valid WSO2 subscription you can have access to WSO2 private Docker images. These images will get updated frequently with bug fixes, security fixes and new improvements. To view available images visit [WSO2 Docker Repositories](https://registry.wso2.com/)
 
 ## Docker command usage references
 

--- a/dockerfiles/rocky/apim-tm/README.md
+++ b/dockerfiles/rocky/apim-tm/README.md
@@ -118,7 +118,7 @@ docker run -it -p 9443:9443 -p 8243:8243 <DOCKER_USERNAME>/wso2am-tm:4.7.0-rocky
 
 ## WSO2 Private Docker images
 
-If you have a valid WSO2 subscription you can have access to WSO2 private Docker images. These images will get updated frequently with bug fixes, security fixes and new improvements. To view available images visit [WSO2 Docker Repositories](https://docker.wso2.com/)
+If you have a valid WSO2 subscription you can have access to WSO2 private Docker images. These images will get updated frequently with bug fixes, security fixes and new improvements. To view available images visit [WSO2 Docker Repositories](https://registry.wso2.com/)
 
 ## Docker command usage references
 

--- a/dockerfiles/rocky/apim-universal-gw/README.md
+++ b/dockerfiles/rocky/apim-universal-gw/README.md
@@ -118,7 +118,7 @@ docker run -it -p 9443:9443 -p 8243:8243 <DOCKER_USERNAME>/wso2am-universal-gw:4
 
 ## WSO2 Private Docker images
 
-If you have a valid WSO2 subscription you can have access to WSO2 private Docker images. These images will get updated frequently with bug fixes, security fixes and new improvements. To view available images visit [WSO2 Docker Repositories](https://docker.wso2.com/)
+If you have a valid WSO2 subscription you can have access to WSO2 private Docker images. These images will get updated frequently with bug fixes, security fixes and new improvements. To view available images visit [WSO2 Docker Repositories](https://registry.wso2.com/)
 
 ## Docker command usage references
 

--- a/dockerfiles/rocky/apim/README.md
+++ b/dockerfiles/rocky/apim/README.md
@@ -118,7 +118,7 @@ docker run -it -p 9443:9443 -p 8243:8243 <DOCKER_USERNAME>/wso2am:4.7.0-rocky
 
 ## WSO2 Private Docker images
 
-If you have a valid WSO2 subscription you can have access to WSO2 private Docker images. These images will get updated frequently with bug fixes, security fixes and new improvements. To view available images visit [WSO2 Docker Repositories](https://docker.wso2.com/)
+If you have a valid WSO2 subscription you can have access to WSO2 private Docker images. These images will get updated frequently with bug fixes, security fixes and new improvements. To view available images visit [WSO2 Docker Repositories](https://registry.wso2.com/)
 
 ## Docker command usage references
 

--- a/dockerfiles/ubuntu/apim-acp/README.md
+++ b/dockerfiles/ubuntu/apim-acp/README.md
@@ -115,7 +115,7 @@ docker run -it -p 9443:9443 -p 8243:8243 <DOCKER_USERNAME>/wso2am-acp:4.7.0
 
 ## WSO2 Private Docker images
 
-If you have a valid WSO2 subscription you can have access to WSO2 private Docker images. These images will get updated frequently with bug fixes, security fixes and new improvements. To view available images visit [WSO2 Docker Repositories](https://docker.wso2.com/)
+If you have a valid WSO2 subscription you can have access to WSO2 private Docker images. These images will get updated frequently with bug fixes, security fixes and new improvements. To view available images visit [WSO2 Docker Repositories](https://registry.wso2.com/)
 
 ## Docker command usage references
 

--- a/dockerfiles/ubuntu/apim-tm/README.md
+++ b/dockerfiles/ubuntu/apim-tm/README.md
@@ -116,7 +116,7 @@ docker run -it -p 9443:9443 -p 8243:8243 <DOCKER_USERNAME>/wso2am-tm:4.7.0
 
 ## WSO2 Private Docker images
 
-If you have a valid WSO2 subscription you can have access to WSO2 private Docker images. These images will get updated frequently with bug fixes, security fixes and new improvements. To view available images visit [WSO2 Docker Repositories](https://docker.wso2.com/)
+If you have a valid WSO2 subscription you can have access to WSO2 private Docker images. These images will get updated frequently with bug fixes, security fixes and new improvements. To view available images visit [WSO2 Docker Repositories](https://registry.wso2.com/)
 
 ## Docker command usage references
 

--- a/dockerfiles/ubuntu/apim-universal-gw/README.md
+++ b/dockerfiles/ubuntu/apim-universal-gw/README.md
@@ -116,7 +116,7 @@ docker run -it -p 9443:9443 -p 8243:8243 <DOCKER_USERNAME>/wso2am-universal-gw:4
 
 ## WSO2 Private Docker images
 
-If you have a valid WSO2 subscription you can have access to WSO2 private Docker images. These images will get updated frequently with bug fixes, security fixes and new improvements. To view available images visit [WSO2 Docker Repositories](https://docker.wso2.com/)
+If you have a valid WSO2 subscription you can have access to WSO2 private Docker images. These images will get updated frequently with bug fixes, security fixes and new improvements. To view available images visit [WSO2 Docker Repositories](https://registry.wso2.com/)
 
 ## Docker command usage references
 

--- a/dockerfiles/ubuntu/apim/README.md
+++ b/dockerfiles/ubuntu/apim/README.md
@@ -116,7 +116,7 @@ docker run -it -p 9443:9443 -p 8243:8243 <DOCKER_USERNAME>/wso2am:4.7.0
 
 ## WSO2 Private Docker images
 
-If you have a valid WSO2 subscription you can have access to WSO2 private Docker images. These images will get updated frequently with bug fixes, security fixes and new improvements. To view available images visit [WSO2 Docker Repositories](https://docker.wso2.com/)
+If you have a valid WSO2 subscription you can have access to WSO2 private Docker images. These images will get updated frequently with bug fixes, security fixes and new improvements. To view available images visit [WSO2 Docker Repositories](https://registry.wso2.com/)
 
 ## Docker command usage references
 


### PR DESCRIPTION
$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Docker base image references for API Manager, Integration Server, and related images to use the new registry endpoint.
* **Documentation**
  * Updated README guidance and docker login/auth instructions to point to the new registry host and image naming conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->