### PR TITLE
Add graceful shutdown handling in docker entrypoint scripts

### DIFF
--- a/dockerfiles/alpine/apim-acp/docker-entrypoint.sh
+++ b/dockerfiles/alpine/apim-acp/docker-entrypoint.sh
@@ -64,6 +64,7 @@ test -d ${artifact_volume} && [[ "$(ls -A ${artifact_volume})" ]] && cp -RL ${ar
 server_pid=""
 
 stop_handler() {
+  trap - SIGTERM SIGINT
   echo "Stopping WSO2 gracefully..." >&2
   if [[ "${PROFILE_NAME}" == "key-manager" ]]
   then
@@ -74,6 +75,7 @@ stop_handler() {
   if [[ -n "${server_pid}" ]]; then
     kill -0 "${server_pid}" 2>/dev/null && wait "${server_pid}"
   fi
+  exit 0
 }
 
 trap 'stop_handler' SIGTERM SIGINT

--- a/dockerfiles/alpine/apim-acp/docker-entrypoint.sh
+++ b/dockerfiles/alpine/apim-acp/docker-entrypoint.sh
@@ -67,11 +67,13 @@ stop_handler() {
   echo "Stopping WSO2 gracefully..." >&2
   if [[ "${PROFILE_NAME}" == "key-manager" ]]
   then
-    sh "${WSO2_SERVER_HOME}/bin/key-manager.sh" stop
+    sh "${WSO2_SERVER_HOME}/bin/key-manager.sh" stop || true
   else
-    sh "${WSO2_SERVER_HOME}/bin/api-cp.sh" stop
+    sh "${WSO2_SERVER_HOME}/bin/api-cp.sh" stop || true
   fi
-  wait "${server_pid}"
+  if [[ -n "${server_pid}" ]]; then
+    wait "${server_pid}"
+  fi
 }
 
 trap 'stop_handler' SIGTERM SIGINT
@@ -81,10 +83,10 @@ echo "Start WSO2 Carbon server" >&2
 if [[ "${PROFILE_NAME}" == "key-manager" ]]
 then
   # start the server with the key-manager profile and provided startup arguments
-  sh ${WSO2_SERVER_HOME}/bin/key-manager.sh "$@" &
+  sh "${WSO2_SERVER_HOME}/bin/key-manager.sh" "$@" &
 else
   # start the server with the control-plane and provided startup arguments
-  sh ${WSO2_SERVER_HOME}/bin/api-cp.sh "$@" &
+  sh "${WSO2_SERVER_HOME}/bin/api-cp.sh" "$@" &
 fi
 server_pid=$!
 wait "${server_pid}"

--- a/dockerfiles/alpine/apim-acp/docker-entrypoint.sh
+++ b/dockerfiles/alpine/apim-acp/docker-entrypoint.sh
@@ -72,7 +72,7 @@ stop_handler() {
     sh "${WSO2_SERVER_HOME}/bin/api-cp.sh" stop || true
   fi
   if [[ -n "${server_pid}" ]]; then
-    wait "${server_pid}"
+    wait "${server_pid}" || sleep 60
   fi
 }
 
@@ -89,4 +89,4 @@ else
   sh "${WSO2_SERVER_HOME}/bin/api-cp.sh" "$@" &
 fi
 server_pid=$!
-wait "${server_pid}"
+wait "${server_pid}" || sleep 60

--- a/dockerfiles/alpine/apim-acp/docker-entrypoint.sh
+++ b/dockerfiles/alpine/apim-acp/docker-entrypoint.sh
@@ -72,7 +72,7 @@ stop_handler() {
     sh "${WSO2_SERVER_HOME}/bin/api-cp.sh" stop || true
   fi
   if [[ -n "${server_pid}" ]]; then
-    wait "${server_pid}" || sleep 60
+    kill -0 "${server_pid}" 2>/dev/null && wait "${server_pid}"
   fi
 }
 
@@ -89,4 +89,4 @@ else
   sh "${WSO2_SERVER_HOME}/bin/api-cp.sh" "$@" &
 fi
 server_pid=$!
-wait "${server_pid}" || sleep 60
+kill -0 "${server_pid}" 2>/dev/null && wait "${server_pid}"

--- a/dockerfiles/alpine/apim-acp/docker-entrypoint.sh
+++ b/dockerfiles/alpine/apim-acp/docker-entrypoint.sh
@@ -61,13 +61,30 @@ test -d ${config_volume} && [[ "$(ls -A ${config_volume})" ]] && cp -RL ${config
 # copy any artifact changes mounted to artifact_volume
 test -d ${artifact_volume} && [[ "$(ls -A ${artifact_volume})" ]] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
+server_pid=""
+
+stop_handler() {
+  echo "Stopping WSO2 gracefully..." >&2
+  if [[ "${PROFILE_NAME}" == "key-manager" ]]
+  then
+    sh "${WSO2_SERVER_HOME}/bin/key-manager.sh" stop
+  else
+    sh "${WSO2_SERVER_HOME}/bin/api-cp.sh" stop
+  fi
+  wait "${server_pid}"
+}
+
+trap 'stop_handler' SIGTERM SIGINT
+
 # start WSO2 Carbon server
 echo "Start WSO2 Carbon server" >&2
 if [[ "${PROFILE_NAME}" == "key-manager" ]]
 then
   # start the server with the key-manager profile and provided startup arguments
-  sh ${WSO2_SERVER_HOME}/bin/key-manager.sh "$@"
+  sh ${WSO2_SERVER_HOME}/bin/key-manager.sh "$@" &
 else
   # start the server with the control-plane and provided startup arguments
-  sh ${WSO2_SERVER_HOME}/bin/api-cp.sh "$@"
+  sh ${WSO2_SERVER_HOME}/bin/api-cp.sh "$@" &
 fi
+server_pid=$!
+wait "${server_pid}"

--- a/dockerfiles/alpine/apim-tm/docker-entrypoint.sh
+++ b/dockerfiles/alpine/apim-tm/docker-entrypoint.sh
@@ -60,7 +60,7 @@ stop_handler() {
   echo "Stopping WSO2 gracefully..." >&2
   sh "${WSO2_SERVER_HOME}/bin/traffic-manager.sh" stop || true
   if [[ -n "${server_pid}" ]]; then
-    wait "${server_pid}" || sleep 60
+    kill -0 "${server_pid}" 2>/dev/null && wait "${server_pid}"
   fi
 }
 
@@ -70,4 +70,4 @@ trap 'stop_handler' SIGTERM SIGINT
 echo "Start WSO2 Carbon server" >&2
 sh "${WSO2_SERVER_HOME}/bin/traffic-manager.sh" "$@" &
 server_pid=$!
-wait "${server_pid}" || sleep 60
+kill -0 "${server_pid}" 2>/dev/null && wait "${server_pid}"

--- a/dockerfiles/alpine/apim-tm/docker-entrypoint.sh
+++ b/dockerfiles/alpine/apim-tm/docker-entrypoint.sh
@@ -57,11 +57,13 @@ test -d ${artifact_volume} && [[ "$(ls -A ${artifact_volume})" ]] && cp -RL ${ar
 server_pid=""
 
 stop_handler() {
+  trap - SIGTERM SIGINT
   echo "Stopping WSO2 gracefully..." >&2
   sh "${WSO2_SERVER_HOME}/bin/traffic-manager.sh" stop || true
   if [[ -n "${server_pid}" ]]; then
     kill -0 "${server_pid}" 2>/dev/null && wait "${server_pid}"
   fi
+  exit 0
 }
 
 trap 'stop_handler' SIGTERM SIGINT

--- a/dockerfiles/alpine/apim-tm/docker-entrypoint.sh
+++ b/dockerfiles/alpine/apim-tm/docker-entrypoint.sh
@@ -60,7 +60,7 @@ stop_handler() {
   echo "Stopping WSO2 gracefully..." >&2
   sh "${WSO2_SERVER_HOME}/bin/traffic-manager.sh" stop || true
   if [[ -n "${server_pid}" ]]; then
-    wait "${server_pid}"
+    wait "${server_pid}" || sleep 60
   fi
 }
 
@@ -70,4 +70,4 @@ trap 'stop_handler' SIGTERM SIGINT
 echo "Start WSO2 Carbon server" >&2
 sh "${WSO2_SERVER_HOME}/bin/traffic-manager.sh" "$@" &
 server_pid=$!
-wait "${server_pid}"
+wait "${server_pid}" || sleep 60

--- a/dockerfiles/alpine/apim-tm/docker-entrypoint.sh
+++ b/dockerfiles/alpine/apim-tm/docker-entrypoint.sh
@@ -54,6 +54,18 @@ test -d ${config_volume} && [[ "$(ls -A ${config_volume})" ]] && cp -RL ${config
 # copy any artifact changes mounted to artifact_volume
 test -d ${artifact_volume} && [[ "$(ls -A ${artifact_volume})" ]] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
+server_pid=""
+
+stop_handler() {
+  echo "Stopping WSO2 gracefully..." >&2
+  sh "${WSO2_SERVER_HOME}/bin/traffic-manager.sh" stop
+  wait "${server_pid}"
+}
+
+trap 'stop_handler' SIGTERM SIGINT
+
 # start WSO2 Carbon server
 echo "Start WSO2 Carbon server" >&2
-sh ${WSO2_SERVER_HOME}/bin/traffic-manager.sh "$@"
+sh ${WSO2_SERVER_HOME}/bin/traffic-manager.sh "$@" &
+server_pid=$!
+wait "${server_pid}"

--- a/dockerfiles/alpine/apim-tm/docker-entrypoint.sh
+++ b/dockerfiles/alpine/apim-tm/docker-entrypoint.sh
@@ -58,14 +58,16 @@ server_pid=""
 
 stop_handler() {
   echo "Stopping WSO2 gracefully..." >&2
-  sh "${WSO2_SERVER_HOME}/bin/traffic-manager.sh" stop
-  wait "${server_pid}"
+  sh "${WSO2_SERVER_HOME}/bin/traffic-manager.sh" stop || true
+  if [[ -n "${server_pid}" ]]; then
+    wait "${server_pid}"
+  fi
 }
 
 trap 'stop_handler' SIGTERM SIGINT
 
 # start WSO2 Carbon server
 echo "Start WSO2 Carbon server" >&2
-sh ${WSO2_SERVER_HOME}/bin/traffic-manager.sh "$@" &
+sh "${WSO2_SERVER_HOME}/bin/traffic-manager.sh" "$@" &
 server_pid=$!
 wait "${server_pid}"

--- a/dockerfiles/alpine/apim-universal-gw/docker-entrypoint.sh
+++ b/dockerfiles/alpine/apim-universal-gw/docker-entrypoint.sh
@@ -54,6 +54,18 @@ test -d ${config_volume} && [[ "$(ls -A ${config_volume})" ]] && cp -RL ${config
 # copy any artifact changes mounted to artifact_volume
 test -d ${artifact_volume} && [[ "$(ls -A ${artifact_volume})" ]] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
+server_pid=""
+
+stop_handler() {
+  echo "Stopping WSO2 gracefully..." >&2
+  sh "${WSO2_SERVER_HOME}/bin/gateway.sh" stop
+  wait "${server_pid}"
+}
+
+trap 'stop_handler' SIGTERM SIGINT
+
 # start WSO2 Carbon server
 echo "Start WSO2 Carbon server" >&2
-sh ${WSO2_SERVER_HOME}/bin/gateway.sh "$@"
+sh ${WSO2_SERVER_HOME}/bin/gateway.sh "$@" &
+server_pid=$!
+wait "${server_pid}"

--- a/dockerfiles/alpine/apim-universal-gw/docker-entrypoint.sh
+++ b/dockerfiles/alpine/apim-universal-gw/docker-entrypoint.sh
@@ -60,7 +60,7 @@ stop_handler() {
   echo "Stopping WSO2 gracefully..." >&2
   sh "${WSO2_SERVER_HOME}/bin/gateway.sh" stop || true
   if [[ -n "${server_pid}" ]]; then
-    wait "${server_pid}" || sleep 60
+    kill -0 "${server_pid}" 2>/dev/null && wait "${server_pid}"
   fi
 }
 
@@ -70,4 +70,4 @@ trap 'stop_handler' SIGTERM SIGINT
 echo "Start WSO2 Carbon server" >&2
 sh "${WSO2_SERVER_HOME}/bin/gateway.sh" "$@" &
 server_pid=$!
-wait "${server_pid}" || sleep 60
+kill -0 "${server_pid}" 2>/dev/null && wait "${server_pid}"

--- a/dockerfiles/alpine/apim-universal-gw/docker-entrypoint.sh
+++ b/dockerfiles/alpine/apim-universal-gw/docker-entrypoint.sh
@@ -57,11 +57,13 @@ test -d ${artifact_volume} && [[ "$(ls -A ${artifact_volume})" ]] && cp -RL ${ar
 server_pid=""
 
 stop_handler() {
+  trap - SIGTERM SIGINT
   echo "Stopping WSO2 gracefully..." >&2
   sh "${WSO2_SERVER_HOME}/bin/gateway.sh" stop || true
   if [[ -n "${server_pid}" ]]; then
     kill -0 "${server_pid}" 2>/dev/null && wait "${server_pid}"
   fi
+  exit 0
 }
 
 trap 'stop_handler' SIGTERM SIGINT

--- a/dockerfiles/alpine/apim-universal-gw/docker-entrypoint.sh
+++ b/dockerfiles/alpine/apim-universal-gw/docker-entrypoint.sh
@@ -58,14 +58,16 @@ server_pid=""
 
 stop_handler() {
   echo "Stopping WSO2 gracefully..." >&2
-  sh "${WSO2_SERVER_HOME}/bin/gateway.sh" stop
-  wait "${server_pid}"
+  sh "${WSO2_SERVER_HOME}/bin/gateway.sh" stop || true
+  if [[ -n "${server_pid}" ]]; then
+    wait "${server_pid}"
+  fi
 }
 
 trap 'stop_handler' SIGTERM SIGINT
 
 # start WSO2 Carbon server
 echo "Start WSO2 Carbon server" >&2
-sh ${WSO2_SERVER_HOME}/bin/gateway.sh "$@" &
+sh "${WSO2_SERVER_HOME}/bin/gateway.sh" "$@" &
 server_pid=$!
 wait "${server_pid}"

--- a/dockerfiles/alpine/apim-universal-gw/docker-entrypoint.sh
+++ b/dockerfiles/alpine/apim-universal-gw/docker-entrypoint.sh
@@ -60,7 +60,7 @@ stop_handler() {
   echo "Stopping WSO2 gracefully..." >&2
   sh "${WSO2_SERVER_HOME}/bin/gateway.sh" stop || true
   if [[ -n "${server_pid}" ]]; then
-    wait "${server_pid}"
+    wait "${server_pid}" || sleep 60
   fi
 }
 
@@ -70,4 +70,4 @@ trap 'stop_handler' SIGTERM SIGINT
 echo "Start WSO2 Carbon server" >&2
 sh "${WSO2_SERVER_HOME}/bin/gateway.sh" "$@" &
 server_pid=$!
-wait "${server_pid}"
+wait "${server_pid}" || sleep 60

--- a/dockerfiles/alpine/apim/docker-entrypoint.sh
+++ b/dockerfiles/alpine/apim/docker-entrypoint.sh
@@ -60,7 +60,7 @@ stop_handler() {
   echo "Stopping WSO2 gracefully..." >&2
   sh "${WSO2_SERVER_HOME}/bin/api-manager.sh" stop || true
   if [[ -n "${server_pid}" ]]; then
-    wait "${server_pid}"
+    wait "${server_pid}" || sleep 60
   fi
 }
 
@@ -70,4 +70,4 @@ trap 'stop_handler' SIGTERM SIGINT
 echo "Start WSO2 Carbon server" >&2
 sh "${WSO2_SERVER_HOME}/bin/api-manager.sh" "$@" &
 server_pid=$!
-wait "${server_pid}"
+wait "${server_pid}" || sleep 60

--- a/dockerfiles/alpine/apim/docker-entrypoint.sh
+++ b/dockerfiles/alpine/apim/docker-entrypoint.sh
@@ -54,6 +54,18 @@ test -d ${config_volume} && [[ "$(ls -A ${config_volume})" ]] && cp -RL ${config
 # copy any artifact changes mounted to artifact_volume
 test -d ${artifact_volume} && [[ "$(ls -A ${artifact_volume})" ]] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
+server_pid=""
+
+stop_handler() {
+  echo "Stopping WSO2 gracefully..." >&2
+  sh "${WSO2_SERVER_HOME}/bin/api-manager.sh" stop
+  wait "${server_pid}"
+}
+
+trap 'stop_handler' SIGTERM SIGINT
+
 # start WSO2 Carbon server
 echo "Start WSO2 Carbon server" >&2
-sh ${WSO2_SERVER_HOME}/bin/api-manager.sh "$@"
+sh ${WSO2_SERVER_HOME}/bin/api-manager.sh "$@" &
+server_pid=$!
+wait "${server_pid}"

--- a/dockerfiles/alpine/apim/docker-entrypoint.sh
+++ b/dockerfiles/alpine/apim/docker-entrypoint.sh
@@ -60,7 +60,7 @@ stop_handler() {
   echo "Stopping WSO2 gracefully..." >&2
   sh "${WSO2_SERVER_HOME}/bin/api-manager.sh" stop || true
   if [[ -n "${server_pid}" ]]; then
-    wait "${server_pid}" || sleep 60
+    kill -0 "${server_pid}" 2>/dev/null && wait "${server_pid}"
   fi
 }
 
@@ -70,4 +70,4 @@ trap 'stop_handler' SIGTERM SIGINT
 echo "Start WSO2 Carbon server" >&2
 sh "${WSO2_SERVER_HOME}/bin/api-manager.sh" "$@" &
 server_pid=$!
-wait "${server_pid}" || sleep 60
+kill -0 "${server_pid}" 2>/dev/null && wait "${server_pid}"

--- a/dockerfiles/alpine/apim/docker-entrypoint.sh
+++ b/dockerfiles/alpine/apim/docker-entrypoint.sh
@@ -57,11 +57,13 @@ test -d ${artifact_volume} && [[ "$(ls -A ${artifact_volume})" ]] && cp -RL ${ar
 server_pid=""
 
 stop_handler() {
+  trap - SIGTERM SIGINT
   echo "Stopping WSO2 gracefully..." >&2
   sh "${WSO2_SERVER_HOME}/bin/api-manager.sh" stop || true
   if [[ -n "${server_pid}" ]]; then
     kill -0 "${server_pid}" 2>/dev/null && wait "${server_pid}"
   fi
+  exit 0
 }
 
 trap 'stop_handler' SIGTERM SIGINT

--- a/dockerfiles/alpine/apim/docker-entrypoint.sh
+++ b/dockerfiles/alpine/apim/docker-entrypoint.sh
@@ -58,14 +58,16 @@ server_pid=""
 
 stop_handler() {
   echo "Stopping WSO2 gracefully..." >&2
-  sh "${WSO2_SERVER_HOME}/bin/api-manager.sh" stop
-  wait "${server_pid}"
+  sh "${WSO2_SERVER_HOME}/bin/api-manager.sh" stop || true
+  if [[ -n "${server_pid}" ]]; then
+    wait "${server_pid}"
+  fi
 }
 
 trap 'stop_handler' SIGTERM SIGINT
 
 # start WSO2 Carbon server
 echo "Start WSO2 Carbon server" >&2
-sh ${WSO2_SERVER_HOME}/bin/api-manager.sh "$@" &
+sh "${WSO2_SERVER_HOME}/bin/api-manager.sh" "$@" &
 server_pid=$!
 wait "${server_pid}"

--- a/dockerfiles/rocky/apim-acp/docker-entrypoint.sh
+++ b/dockerfiles/rocky/apim-acp/docker-entrypoint.sh
@@ -64,6 +64,7 @@ test -d ${artifact_volume} && [[ "$(ls -A ${artifact_volume})" ]] && cp -RL ${ar
 server_pid=""
 
 stop_handler() {
+  trap - SIGTERM SIGINT
   echo "Stopping WSO2 gracefully..." >&2
   if [[ "${PROFILE_NAME}" == "key-manager" ]]
   then
@@ -74,6 +75,7 @@ stop_handler() {
   if [[ -n "${server_pid}" ]]; then
     kill -0 "${server_pid}" 2>/dev/null && wait "${server_pid}"
   fi
+  exit 0
 }
 
 trap 'stop_handler' SIGTERM SIGINT

--- a/dockerfiles/rocky/apim-acp/docker-entrypoint.sh
+++ b/dockerfiles/rocky/apim-acp/docker-entrypoint.sh
@@ -67,11 +67,13 @@ stop_handler() {
   echo "Stopping WSO2 gracefully..." >&2
   if [[ "${PROFILE_NAME}" == "key-manager" ]]
   then
-    sh "${WSO2_SERVER_HOME}/bin/key-manager.sh" stop
+    sh "${WSO2_SERVER_HOME}/bin/key-manager.sh" stop || true
   else
-    sh "${WSO2_SERVER_HOME}/bin/api-cp.sh" stop
+    sh "${WSO2_SERVER_HOME}/bin/api-cp.sh" stop || true
   fi
-  wait "${server_pid}"
+  if [[ -n "${server_pid}" ]]; then
+    wait "${server_pid}"
+  fi
 }
 
 trap 'stop_handler' SIGTERM SIGINT
@@ -81,10 +83,10 @@ echo "Start WSO2 Carbon server" >&2
 if [[ "${PROFILE_NAME}" == "key-manager" ]]
 then
   # start the server with the key-manager profile and provided startup arguments
-  sh ${WSO2_SERVER_HOME}/bin/key-manager.sh "$@" &
+  sh "${WSO2_SERVER_HOME}/bin/key-manager.sh" "$@" &
 else
   # start the server with the control-plane and provided startup arguments
-  sh ${WSO2_SERVER_HOME}/bin/api-cp.sh "$@" &
+  sh "${WSO2_SERVER_HOME}/bin/api-cp.sh" "$@" &
 fi
 server_pid=$!
 wait "${server_pid}"

--- a/dockerfiles/rocky/apim-acp/docker-entrypoint.sh
+++ b/dockerfiles/rocky/apim-acp/docker-entrypoint.sh
@@ -72,7 +72,7 @@ stop_handler() {
     sh "${WSO2_SERVER_HOME}/bin/api-cp.sh" stop || true
   fi
   if [[ -n "${server_pid}" ]]; then
-    wait "${server_pid}"
+    wait "${server_pid}" || sleep 60
   fi
 }
 
@@ -89,4 +89,4 @@ else
   sh "${WSO2_SERVER_HOME}/bin/api-cp.sh" "$@" &
 fi
 server_pid=$!
-wait "${server_pid}"
+wait "${server_pid}" || sleep 60

--- a/dockerfiles/rocky/apim-acp/docker-entrypoint.sh
+++ b/dockerfiles/rocky/apim-acp/docker-entrypoint.sh
@@ -72,7 +72,7 @@ stop_handler() {
     sh "${WSO2_SERVER_HOME}/bin/api-cp.sh" stop || true
   fi
   if [[ -n "${server_pid}" ]]; then
-    wait "${server_pid}" || sleep 60
+    kill -0 "${server_pid}" 2>/dev/null && wait "${server_pid}"
   fi
 }
 
@@ -89,4 +89,4 @@ else
   sh "${WSO2_SERVER_HOME}/bin/api-cp.sh" "$@" &
 fi
 server_pid=$!
-wait "${server_pid}" || sleep 60
+kill -0 "${server_pid}" 2>/dev/null && wait "${server_pid}"

--- a/dockerfiles/rocky/apim-acp/docker-entrypoint.sh
+++ b/dockerfiles/rocky/apim-acp/docker-entrypoint.sh
@@ -61,13 +61,30 @@ test -d ${config_volume} && [[ "$(ls -A ${config_volume})" ]] && cp -RL ${config
 # copy any artifact changes mounted to artifact_volume
 test -d ${artifact_volume} && [[ "$(ls -A ${artifact_volume})" ]] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
+server_pid=""
+
+stop_handler() {
+  echo "Stopping WSO2 gracefully..." >&2
+  if [[ "${PROFILE_NAME}" == "key-manager" ]]
+  then
+    sh "${WSO2_SERVER_HOME}/bin/key-manager.sh" stop
+  else
+    sh "${WSO2_SERVER_HOME}/bin/api-cp.sh" stop
+  fi
+  wait "${server_pid}"
+}
+
+trap 'stop_handler' SIGTERM SIGINT
+
 # start WSO2 Carbon server
 echo "Start WSO2 Carbon server" >&2
 if [[ "${PROFILE_NAME}" == "key-manager" ]]
 then
   # start the server with the key-manager profile and provided startup arguments
-  sh ${WSO2_SERVER_HOME}/bin/key-manager.sh "$@"
+  sh ${WSO2_SERVER_HOME}/bin/key-manager.sh "$@" &
 else
   # start the server with the control-plane and provided startup arguments
-  sh ${WSO2_SERVER_HOME}/bin/api-cp.sh "$@"
+  sh ${WSO2_SERVER_HOME}/bin/api-cp.sh "$@" &
 fi
+server_pid=$!
+wait "${server_pid}"

--- a/dockerfiles/rocky/apim-tm/docker-entrypoint.sh
+++ b/dockerfiles/rocky/apim-tm/docker-entrypoint.sh
@@ -60,7 +60,7 @@ stop_handler() {
   echo "Stopping WSO2 gracefully..." >&2
   sh "${WSO2_SERVER_HOME}/bin/traffic-manager.sh" stop || true
   if [[ -n "${server_pid}" ]]; then
-    wait "${server_pid}" || sleep 60
+    kill -0 "${server_pid}" 2>/dev/null && wait "${server_pid}"
   fi
 }
 
@@ -70,4 +70,4 @@ trap 'stop_handler' SIGTERM SIGINT
 echo "Start WSO2 Carbon server" >&2
 sh "${WSO2_SERVER_HOME}/bin/traffic-manager.sh" "$@" &
 server_pid=$!
-wait "${server_pid}" || sleep 60
+kill -0 "${server_pid}" 2>/dev/null && wait "${server_pid}"

--- a/dockerfiles/rocky/apim-tm/docker-entrypoint.sh
+++ b/dockerfiles/rocky/apim-tm/docker-entrypoint.sh
@@ -57,11 +57,13 @@ test -d ${artifact_volume} && [[ "$(ls -A ${artifact_volume})" ]] && cp -RL ${ar
 server_pid=""
 
 stop_handler() {
+  trap - SIGTERM SIGINT
   echo "Stopping WSO2 gracefully..." >&2
   sh "${WSO2_SERVER_HOME}/bin/traffic-manager.sh" stop || true
   if [[ -n "${server_pid}" ]]; then
     kill -0 "${server_pid}" 2>/dev/null && wait "${server_pid}"
   fi
+  exit 0
 }
 
 trap 'stop_handler' SIGTERM SIGINT

--- a/dockerfiles/rocky/apim-tm/docker-entrypoint.sh
+++ b/dockerfiles/rocky/apim-tm/docker-entrypoint.sh
@@ -60,7 +60,7 @@ stop_handler() {
   echo "Stopping WSO2 gracefully..." >&2
   sh "${WSO2_SERVER_HOME}/bin/traffic-manager.sh" stop || true
   if [[ -n "${server_pid}" ]]; then
-    wait "${server_pid}"
+    wait "${server_pid}" || sleep 60
   fi
 }
 
@@ -70,4 +70,4 @@ trap 'stop_handler' SIGTERM SIGINT
 echo "Start WSO2 Carbon server" >&2
 sh "${WSO2_SERVER_HOME}/bin/traffic-manager.sh" "$@" &
 server_pid=$!
-wait "${server_pid}"
+wait "${server_pid}" || sleep 60

--- a/dockerfiles/rocky/apim-tm/docker-entrypoint.sh
+++ b/dockerfiles/rocky/apim-tm/docker-entrypoint.sh
@@ -54,6 +54,18 @@ test -d ${config_volume} && [[ "$(ls -A ${config_volume})" ]] && cp -RL ${config
 # copy any artifact changes mounted to artifact_volume
 test -d ${artifact_volume} && [[ "$(ls -A ${artifact_volume})" ]] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
+server_pid=""
+
+stop_handler() {
+  echo "Stopping WSO2 gracefully..." >&2
+  sh "${WSO2_SERVER_HOME}/bin/traffic-manager.sh" stop
+  wait "${server_pid}"
+}
+
+trap 'stop_handler' SIGTERM SIGINT
+
 # start WSO2 Carbon server
 echo "Start WSO2 Carbon server" >&2
-sh ${WSO2_SERVER_HOME}/bin/traffic-manager.sh "$@"
+sh ${WSO2_SERVER_HOME}/bin/traffic-manager.sh "$@" &
+server_pid=$!
+wait "${server_pid}"

--- a/dockerfiles/rocky/apim-tm/docker-entrypoint.sh
+++ b/dockerfiles/rocky/apim-tm/docker-entrypoint.sh
@@ -58,14 +58,16 @@ server_pid=""
 
 stop_handler() {
   echo "Stopping WSO2 gracefully..." >&2
-  sh "${WSO2_SERVER_HOME}/bin/traffic-manager.sh" stop
-  wait "${server_pid}"
+  sh "${WSO2_SERVER_HOME}/bin/traffic-manager.sh" stop || true
+  if [[ -n "${server_pid}" ]]; then
+    wait "${server_pid}"
+  fi
 }
 
 trap 'stop_handler' SIGTERM SIGINT
 
 # start WSO2 Carbon server
 echo "Start WSO2 Carbon server" >&2
-sh ${WSO2_SERVER_HOME}/bin/traffic-manager.sh "$@" &
+sh "${WSO2_SERVER_HOME}/bin/traffic-manager.sh" "$@" &
 server_pid=$!
 wait "${server_pid}"

--- a/dockerfiles/rocky/apim-universal-gw/docker-entrypoint.sh
+++ b/dockerfiles/rocky/apim-universal-gw/docker-entrypoint.sh
@@ -54,6 +54,18 @@ test -d ${config_volume} && [[ "$(ls -A ${config_volume})" ]] && cp -RL ${config
 # copy any artifact changes mounted to artifact_volume
 test -d ${artifact_volume} && [[ "$(ls -A ${artifact_volume})" ]] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
+server_pid=""
+
+stop_handler() {
+  echo "Stopping WSO2 gracefully..." >&2
+  sh "${WSO2_SERVER_HOME}/bin/gateway.sh" stop
+  wait "${server_pid}"
+}
+
+trap 'stop_handler' SIGTERM SIGINT
+
 # start WSO2 Carbon server
 echo "Start WSO2 Carbon server" >&2
-sh ${WSO2_SERVER_HOME}/bin/gateway.sh "$@"
+sh ${WSO2_SERVER_HOME}/bin/gateway.sh "$@" &
+server_pid=$!
+wait "${server_pid}"

--- a/dockerfiles/rocky/apim-universal-gw/docker-entrypoint.sh
+++ b/dockerfiles/rocky/apim-universal-gw/docker-entrypoint.sh
@@ -60,7 +60,7 @@ stop_handler() {
   echo "Stopping WSO2 gracefully..." >&2
   sh "${WSO2_SERVER_HOME}/bin/gateway.sh" stop || true
   if [[ -n "${server_pid}" ]]; then
-    wait "${server_pid}" || sleep 60
+    kill -0 "${server_pid}" 2>/dev/null && wait "${server_pid}"
   fi
 }
 
@@ -70,4 +70,4 @@ trap 'stop_handler' SIGTERM SIGINT
 echo "Start WSO2 Carbon server" >&2
 sh "${WSO2_SERVER_HOME}/bin/gateway.sh" "$@" &
 server_pid=$!
-wait "${server_pid}" || sleep 60
+kill -0 "${server_pid}" 2>/dev/null && wait "${server_pid}"

--- a/dockerfiles/rocky/apim-universal-gw/docker-entrypoint.sh
+++ b/dockerfiles/rocky/apim-universal-gw/docker-entrypoint.sh
@@ -57,11 +57,13 @@ test -d ${artifact_volume} && [[ "$(ls -A ${artifact_volume})" ]] && cp -RL ${ar
 server_pid=""
 
 stop_handler() {
+  trap - SIGTERM SIGINT
   echo "Stopping WSO2 gracefully..." >&2
   sh "${WSO2_SERVER_HOME}/bin/gateway.sh" stop || true
   if [[ -n "${server_pid}" ]]; then
     kill -0 "${server_pid}" 2>/dev/null && wait "${server_pid}"
   fi
+  exit 0
 }
 
 trap 'stop_handler' SIGTERM SIGINT

--- a/dockerfiles/rocky/apim-universal-gw/docker-entrypoint.sh
+++ b/dockerfiles/rocky/apim-universal-gw/docker-entrypoint.sh
@@ -58,14 +58,16 @@ server_pid=""
 
 stop_handler() {
   echo "Stopping WSO2 gracefully..." >&2
-  sh "${WSO2_SERVER_HOME}/bin/gateway.sh" stop
-  wait "${server_pid}"
+  sh "${WSO2_SERVER_HOME}/bin/gateway.sh" stop || true
+  if [[ -n "${server_pid}" ]]; then
+    wait "${server_pid}"
+  fi
 }
 
 trap 'stop_handler' SIGTERM SIGINT
 
 # start WSO2 Carbon server
 echo "Start WSO2 Carbon server" >&2
-sh ${WSO2_SERVER_HOME}/bin/gateway.sh "$@" &
+sh "${WSO2_SERVER_HOME}/bin/gateway.sh" "$@" &
 server_pid=$!
 wait "${server_pid}"

--- a/dockerfiles/rocky/apim-universal-gw/docker-entrypoint.sh
+++ b/dockerfiles/rocky/apim-universal-gw/docker-entrypoint.sh
@@ -60,7 +60,7 @@ stop_handler() {
   echo "Stopping WSO2 gracefully..." >&2
   sh "${WSO2_SERVER_HOME}/bin/gateway.sh" stop || true
   if [[ -n "${server_pid}" ]]; then
-    wait "${server_pid}"
+    wait "${server_pid}" || sleep 60
   fi
 }
 
@@ -70,4 +70,4 @@ trap 'stop_handler' SIGTERM SIGINT
 echo "Start WSO2 Carbon server" >&2
 sh "${WSO2_SERVER_HOME}/bin/gateway.sh" "$@" &
 server_pid=$!
-wait "${server_pid}"
+wait "${server_pid}" || sleep 60

--- a/dockerfiles/rocky/apim/docker-entrypoint.sh
+++ b/dockerfiles/rocky/apim/docker-entrypoint.sh
@@ -60,7 +60,7 @@ stop_handler() {
   echo "Stopping WSO2 gracefully..." >&2
   sh "${WSO2_SERVER_HOME}/bin/api-manager.sh" stop || true
   if [[ -n "${server_pid}" ]]; then
-    wait "${server_pid}"
+    wait "${server_pid}" || sleep 60
   fi
 }
 
@@ -70,4 +70,4 @@ trap 'stop_handler' SIGTERM SIGINT
 echo "Start WSO2 Carbon server" >&2
 sh "${WSO2_SERVER_HOME}/bin/api-manager.sh" "$@" &
 server_pid=$!
-wait "${server_pid}"
+wait "${server_pid}" || sleep 60

--- a/dockerfiles/rocky/apim/docker-entrypoint.sh
+++ b/dockerfiles/rocky/apim/docker-entrypoint.sh
@@ -54,6 +54,18 @@ test -d ${config_volume} && [[ "$(ls -A ${config_volume})" ]] && cp -RL ${config
 # copy any artifact changes mounted to artifact_volume
 test -d ${artifact_volume} && [[ "$(ls -A ${artifact_volume})" ]] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
+server_pid=""
+
+stop_handler() {
+  echo "Stopping WSO2 gracefully..." >&2
+  sh "${WSO2_SERVER_HOME}/bin/api-manager.sh" stop
+  wait "${server_pid}"
+}
+
+trap 'stop_handler' SIGTERM SIGINT
+
 # start WSO2 Carbon server
 echo "Start WSO2 Carbon server" >&2
-sh ${WSO2_SERVER_HOME}/bin/api-manager.sh "$@"
+sh ${WSO2_SERVER_HOME}/bin/api-manager.sh "$@" &
+server_pid=$!
+wait "${server_pid}"

--- a/dockerfiles/rocky/apim/docker-entrypoint.sh
+++ b/dockerfiles/rocky/apim/docker-entrypoint.sh
@@ -60,7 +60,7 @@ stop_handler() {
   echo "Stopping WSO2 gracefully..." >&2
   sh "${WSO2_SERVER_HOME}/bin/api-manager.sh" stop || true
   if [[ -n "${server_pid}" ]]; then
-    wait "${server_pid}" || sleep 60
+    kill -0 "${server_pid}" 2>/dev/null && wait "${server_pid}"
   fi
 }
 
@@ -70,4 +70,4 @@ trap 'stop_handler' SIGTERM SIGINT
 echo "Start WSO2 Carbon server" >&2
 sh "${WSO2_SERVER_HOME}/bin/api-manager.sh" "$@" &
 server_pid=$!
-wait "${server_pid}" || sleep 60
+kill -0 "${server_pid}" 2>/dev/null && wait "${server_pid}"

--- a/dockerfiles/rocky/apim/docker-entrypoint.sh
+++ b/dockerfiles/rocky/apim/docker-entrypoint.sh
@@ -57,11 +57,13 @@ test -d ${artifact_volume} && [[ "$(ls -A ${artifact_volume})" ]] && cp -RL ${ar
 server_pid=""
 
 stop_handler() {
+  trap - SIGTERM SIGINT
   echo "Stopping WSO2 gracefully..." >&2
   sh "${WSO2_SERVER_HOME}/bin/api-manager.sh" stop || true
   if [[ -n "${server_pid}" ]]; then
     kill -0 "${server_pid}" 2>/dev/null && wait "${server_pid}"
   fi
+  exit 0
 }
 
 trap 'stop_handler' SIGTERM SIGINT

--- a/dockerfiles/rocky/apim/docker-entrypoint.sh
+++ b/dockerfiles/rocky/apim/docker-entrypoint.sh
@@ -58,14 +58,16 @@ server_pid=""
 
 stop_handler() {
   echo "Stopping WSO2 gracefully..." >&2
-  sh "${WSO2_SERVER_HOME}/bin/api-manager.sh" stop
-  wait "${server_pid}"
+  sh "${WSO2_SERVER_HOME}/bin/api-manager.sh" stop || true
+  if [[ -n "${server_pid}" ]]; then
+    wait "${server_pid}"
+  fi
 }
 
 trap 'stop_handler' SIGTERM SIGINT
 
 # start WSO2 Carbon server
 echo "Start WSO2 Carbon server" >&2
-sh ${WSO2_SERVER_HOME}/bin/api-manager.sh "$@" &
+sh "${WSO2_SERVER_HOME}/bin/api-manager.sh" "$@" &
 server_pid=$!
 wait "${server_pid}"

--- a/dockerfiles/ubuntu/apim-acp/docker-entrypoint.sh
+++ b/dockerfiles/ubuntu/apim-acp/docker-entrypoint.sh
@@ -64,6 +64,7 @@ test -d ${artifact_volume} && [[ "$(ls -A ${artifact_volume})" ]] && cp -RL ${ar
 server_pid=""
 
 stop_handler() {
+  trap - SIGTERM SIGINT
   echo "Stopping WSO2 gracefully..." >&2
   if [[ "${PROFILE_NAME}" == "key-manager" ]]
   then
@@ -74,6 +75,7 @@ stop_handler() {
   if [[ -n "${server_pid}" ]]; then
     kill -0 "${server_pid}" 2>/dev/null && wait "${server_pid}"
   fi
+  exit 0
 }
 
 trap 'stop_handler' SIGTERM SIGINT

--- a/dockerfiles/ubuntu/apim-acp/docker-entrypoint.sh
+++ b/dockerfiles/ubuntu/apim-acp/docker-entrypoint.sh
@@ -67,11 +67,13 @@ stop_handler() {
   echo "Stopping WSO2 gracefully..." >&2
   if [[ "${PROFILE_NAME}" == "key-manager" ]]
   then
-    sh "${WSO2_SERVER_HOME}/bin/key-manager.sh" stop
+    sh "${WSO2_SERVER_HOME}/bin/key-manager.sh" stop || true
   else
-    sh "${WSO2_SERVER_HOME}/bin/api-cp.sh" stop
+    sh "${WSO2_SERVER_HOME}/bin/api-cp.sh" stop || true
   fi
-  wait "${server_pid}"
+  if [[ -n "${server_pid}" ]]; then
+    wait "${server_pid}"
+  fi
 }
 
 trap 'stop_handler' SIGTERM SIGINT
@@ -81,10 +83,10 @@ echo "Start WSO2 Carbon server" >&2
 if [[ "${PROFILE_NAME}" == "key-manager" ]]
 then
   # start the server with the key-manager profile and provided startup arguments
-  sh ${WSO2_SERVER_HOME}/bin/key-manager.sh "$@" &
+  sh "${WSO2_SERVER_HOME}/bin/key-manager.sh" "$@" &
 else
   # start the server with the control-plane and provided startup arguments
-  sh ${WSO2_SERVER_HOME}/bin/api-cp.sh "$@" &
+  sh "${WSO2_SERVER_HOME}/bin/api-cp.sh" "$@" &
 fi
 server_pid=$!
 wait "${server_pid}"

--- a/dockerfiles/ubuntu/apim-acp/docker-entrypoint.sh
+++ b/dockerfiles/ubuntu/apim-acp/docker-entrypoint.sh
@@ -72,7 +72,7 @@ stop_handler() {
     sh "${WSO2_SERVER_HOME}/bin/api-cp.sh" stop || true
   fi
   if [[ -n "${server_pid}" ]]; then
-    wait "${server_pid}"
+    wait "${server_pid}" || sleep 60
   fi
 }
 
@@ -89,4 +89,4 @@ else
   sh "${WSO2_SERVER_HOME}/bin/api-cp.sh" "$@" &
 fi
 server_pid=$!
-wait "${server_pid}"
+wait "${server_pid}" || sleep 60

--- a/dockerfiles/ubuntu/apim-acp/docker-entrypoint.sh
+++ b/dockerfiles/ubuntu/apim-acp/docker-entrypoint.sh
@@ -72,7 +72,7 @@ stop_handler() {
     sh "${WSO2_SERVER_HOME}/bin/api-cp.sh" stop || true
   fi
   if [[ -n "${server_pid}" ]]; then
-    wait "${server_pid}" || sleep 60
+    kill -0 "${server_pid}" 2>/dev/null && wait "${server_pid}"
   fi
 }
 
@@ -89,4 +89,4 @@ else
   sh "${WSO2_SERVER_HOME}/bin/api-cp.sh" "$@" &
 fi
 server_pid=$!
-wait "${server_pid}" || sleep 60
+kill -0 "${server_pid}" 2>/dev/null && wait "${server_pid}"

--- a/dockerfiles/ubuntu/apim-acp/docker-entrypoint.sh
+++ b/dockerfiles/ubuntu/apim-acp/docker-entrypoint.sh
@@ -61,13 +61,30 @@ test -d ${config_volume} && [[ "$(ls -A ${config_volume})" ]] && cp -RL ${config
 # copy any artifact changes mounted to artifact_volume
 test -d ${artifact_volume} && [[ "$(ls -A ${artifact_volume})" ]] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
+server_pid=""
+
+stop_handler() {
+  echo "Stopping WSO2 gracefully..." >&2
+  if [[ "${PROFILE_NAME}" == "key-manager" ]]
+  then
+    sh "${WSO2_SERVER_HOME}/bin/key-manager.sh" stop
+  else
+    sh "${WSO2_SERVER_HOME}/bin/api-cp.sh" stop
+  fi
+  wait "${server_pid}"
+}
+
+trap 'stop_handler' SIGTERM SIGINT
+
 # start WSO2 Carbon server
 echo "Start WSO2 Carbon server" >&2
 if [[ "${PROFILE_NAME}" == "key-manager" ]]
 then
   # start the server with the key-manager profile and provided startup arguments
-  sh ${WSO2_SERVER_HOME}/bin/key-manager.sh "$@"
+  sh ${WSO2_SERVER_HOME}/bin/key-manager.sh "$@" &
 else
   # start the server with the control-plane and provided startup arguments
-  sh ${WSO2_SERVER_HOME}/bin/api-cp.sh "$@"
+  sh ${WSO2_SERVER_HOME}/bin/api-cp.sh "$@" &
 fi
+server_pid=$!
+wait "${server_pid}"

--- a/dockerfiles/ubuntu/apim-tm/docker-entrypoint.sh
+++ b/dockerfiles/ubuntu/apim-tm/docker-entrypoint.sh
@@ -60,7 +60,7 @@ stop_handler() {
   echo "Stopping WSO2 gracefully..." >&2
   sh "${WSO2_SERVER_HOME}/bin/traffic-manager.sh" stop || true
   if [[ -n "${server_pid}" ]]; then
-    wait "${server_pid}" || sleep 60
+    kill -0 "${server_pid}" 2>/dev/null && wait "${server_pid}"
   fi
 }
 
@@ -70,4 +70,4 @@ trap 'stop_handler' SIGTERM SIGINT
 echo "Start WSO2 Carbon server" >&2
 sh "${WSO2_SERVER_HOME}/bin/traffic-manager.sh" "$@" &
 server_pid=$!
-wait "${server_pid}" || sleep 60
+kill -0 "${server_pid}" 2>/dev/null && wait "${server_pid}"

--- a/dockerfiles/ubuntu/apim-tm/docker-entrypoint.sh
+++ b/dockerfiles/ubuntu/apim-tm/docker-entrypoint.sh
@@ -57,11 +57,13 @@ test -d ${artifact_volume} && [[ "$(ls -A ${artifact_volume})" ]] && cp -RL ${ar
 server_pid=""
 
 stop_handler() {
+  trap - SIGTERM SIGINT
   echo "Stopping WSO2 gracefully..." >&2
   sh "${WSO2_SERVER_HOME}/bin/traffic-manager.sh" stop || true
   if [[ -n "${server_pid}" ]]; then
     kill -0 "${server_pid}" 2>/dev/null && wait "${server_pid}"
   fi
+  exit 0
 }
 
 trap 'stop_handler' SIGTERM SIGINT

--- a/dockerfiles/ubuntu/apim-tm/docker-entrypoint.sh
+++ b/dockerfiles/ubuntu/apim-tm/docker-entrypoint.sh
@@ -60,7 +60,7 @@ stop_handler() {
   echo "Stopping WSO2 gracefully..." >&2
   sh "${WSO2_SERVER_HOME}/bin/traffic-manager.sh" stop || true
   if [[ -n "${server_pid}" ]]; then
-    wait "${server_pid}"
+    wait "${server_pid}" || sleep 60
   fi
 }
 
@@ -70,4 +70,4 @@ trap 'stop_handler' SIGTERM SIGINT
 echo "Start WSO2 Carbon server" >&2
 sh "${WSO2_SERVER_HOME}/bin/traffic-manager.sh" "$@" &
 server_pid=$!
-wait "${server_pid}"
+wait "${server_pid}" || sleep 60

--- a/dockerfiles/ubuntu/apim-tm/docker-entrypoint.sh
+++ b/dockerfiles/ubuntu/apim-tm/docker-entrypoint.sh
@@ -54,6 +54,18 @@ test -d ${config_volume} && [[ "$(ls -A ${config_volume})" ]] && cp -RL ${config
 # copy any artifact changes mounted to artifact_volume
 test -d ${artifact_volume} && [[ "$(ls -A ${artifact_volume})" ]] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
+server_pid=""
+
+stop_handler() {
+  echo "Stopping WSO2 gracefully..." >&2
+  sh "${WSO2_SERVER_HOME}/bin/traffic-manager.sh" stop
+  wait "${server_pid}"
+}
+
+trap 'stop_handler' SIGTERM SIGINT
+
 # start WSO2 Carbon server
 echo "Start WSO2 Carbon server" >&2
-sh ${WSO2_SERVER_HOME}/bin/traffic-manager.sh "$@"
+sh ${WSO2_SERVER_HOME}/bin/traffic-manager.sh "$@" &
+server_pid=$!
+wait "${server_pid}"

--- a/dockerfiles/ubuntu/apim-tm/docker-entrypoint.sh
+++ b/dockerfiles/ubuntu/apim-tm/docker-entrypoint.sh
@@ -58,14 +58,16 @@ server_pid=""
 
 stop_handler() {
   echo "Stopping WSO2 gracefully..." >&2
-  sh "${WSO2_SERVER_HOME}/bin/traffic-manager.sh" stop
-  wait "${server_pid}"
+  sh "${WSO2_SERVER_HOME}/bin/traffic-manager.sh" stop || true
+  if [[ -n "${server_pid}" ]]; then
+    wait "${server_pid}"
+  fi
 }
 
 trap 'stop_handler' SIGTERM SIGINT
 
 # start WSO2 Carbon server
 echo "Start WSO2 Carbon server" >&2
-sh ${WSO2_SERVER_HOME}/bin/traffic-manager.sh "$@" &
+sh "${WSO2_SERVER_HOME}/bin/traffic-manager.sh" "$@" &
 server_pid=$!
 wait "${server_pid}"

--- a/dockerfiles/ubuntu/apim-universal-gw/docker-entrypoint.sh
+++ b/dockerfiles/ubuntu/apim-universal-gw/docker-entrypoint.sh
@@ -54,6 +54,18 @@ test -d ${config_volume} && [[ "$(ls -A ${config_volume})" ]] && cp -RL ${config
 # copy any artifact changes mounted to artifact_volume
 test -d ${artifact_volume} && [[ "$(ls -A ${artifact_volume})" ]] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
+server_pid=""
+
+stop_handler() {
+  echo "Stopping WSO2 gracefully..." >&2
+  sh "${WSO2_SERVER_HOME}/bin/gateway.sh" stop
+  wait "${server_pid}"
+}
+
+trap 'stop_handler' SIGTERM SIGINT
+
 # start WSO2 Carbon server
 echo "Start WSO2 Carbon server" >&2
-sh ${WSO2_SERVER_HOME}/bin/gateway.sh "$@"
+sh ${WSO2_SERVER_HOME}/bin/gateway.sh "$@" &
+server_pid=$!
+wait "${server_pid}"

--- a/dockerfiles/ubuntu/apim-universal-gw/docker-entrypoint.sh
+++ b/dockerfiles/ubuntu/apim-universal-gw/docker-entrypoint.sh
@@ -60,7 +60,7 @@ stop_handler() {
   echo "Stopping WSO2 gracefully..." >&2
   sh "${WSO2_SERVER_HOME}/bin/gateway.sh" stop || true
   if [[ -n "${server_pid}" ]]; then
-    wait "${server_pid}" || sleep 60
+    kill -0 "${server_pid}" 2>/dev/null && wait "${server_pid}"
   fi
 }
 
@@ -70,4 +70,4 @@ trap 'stop_handler' SIGTERM SIGINT
 echo "Start WSO2 Carbon server" >&2
 sh "${WSO2_SERVER_HOME}/bin/gateway.sh" "$@" &
 server_pid=$!
-wait "${server_pid}" || sleep 60
+kill -0 "${server_pid}" 2>/dev/null && wait "${server_pid}"

--- a/dockerfiles/ubuntu/apim-universal-gw/docker-entrypoint.sh
+++ b/dockerfiles/ubuntu/apim-universal-gw/docker-entrypoint.sh
@@ -57,11 +57,13 @@ test -d ${artifact_volume} && [[ "$(ls -A ${artifact_volume})" ]] && cp -RL ${ar
 server_pid=""
 
 stop_handler() {
+  trap - SIGTERM SIGINT
   echo "Stopping WSO2 gracefully..." >&2
   sh "${WSO2_SERVER_HOME}/bin/gateway.sh" stop || true
   if [[ -n "${server_pid}" ]]; then
     kill -0 "${server_pid}" 2>/dev/null && wait "${server_pid}"
   fi
+  exit 0
 }
 
 trap 'stop_handler' SIGTERM SIGINT

--- a/dockerfiles/ubuntu/apim-universal-gw/docker-entrypoint.sh
+++ b/dockerfiles/ubuntu/apim-universal-gw/docker-entrypoint.sh
@@ -58,14 +58,16 @@ server_pid=""
 
 stop_handler() {
   echo "Stopping WSO2 gracefully..." >&2
-  sh "${WSO2_SERVER_HOME}/bin/gateway.sh" stop
-  wait "${server_pid}"
+  sh "${WSO2_SERVER_HOME}/bin/gateway.sh" stop || true
+  if [[ -n "${server_pid}" ]]; then
+    wait "${server_pid}"
+  fi
 }
 
 trap 'stop_handler' SIGTERM SIGINT
 
 # start WSO2 Carbon server
 echo "Start WSO2 Carbon server" >&2
-sh ${WSO2_SERVER_HOME}/bin/gateway.sh "$@" &
+sh "${WSO2_SERVER_HOME}/bin/gateway.sh" "$@" &
 server_pid=$!
 wait "${server_pid}"

--- a/dockerfiles/ubuntu/apim-universal-gw/docker-entrypoint.sh
+++ b/dockerfiles/ubuntu/apim-universal-gw/docker-entrypoint.sh
@@ -60,7 +60,7 @@ stop_handler() {
   echo "Stopping WSO2 gracefully..." >&2
   sh "${WSO2_SERVER_HOME}/bin/gateway.sh" stop || true
   if [[ -n "${server_pid}" ]]; then
-    wait "${server_pid}"
+    wait "${server_pid}" || sleep 60
   fi
 }
 
@@ -70,4 +70,4 @@ trap 'stop_handler' SIGTERM SIGINT
 echo "Start WSO2 Carbon server" >&2
 sh "${WSO2_SERVER_HOME}/bin/gateway.sh" "$@" &
 server_pid=$!
-wait "${server_pid}"
+wait "${server_pid}" || sleep 60

--- a/dockerfiles/ubuntu/apim/docker-entrypoint.sh
+++ b/dockerfiles/ubuntu/apim/docker-entrypoint.sh
@@ -60,7 +60,7 @@ stop_handler() {
   echo "Stopping WSO2 gracefully..." >&2
   sh "${WSO2_SERVER_HOME}/bin/api-manager.sh" stop || true
   if [[ -n "${server_pid}" ]]; then
-    wait "${server_pid}"
+    wait "${server_pid}" || sleep 60
   fi
 }
 
@@ -70,4 +70,4 @@ trap 'stop_handler' SIGTERM SIGINT
 echo "Start WSO2 Carbon server" >&2
 sh "${WSO2_SERVER_HOME}/bin/api-manager.sh" "$@" &
 server_pid=$!
-wait "${server_pid}"
+wait "${server_pid}" || sleep 60

--- a/dockerfiles/ubuntu/apim/docker-entrypoint.sh
+++ b/dockerfiles/ubuntu/apim/docker-entrypoint.sh
@@ -54,6 +54,18 @@ test -d ${config_volume} && [[ "$(ls -A ${config_volume})" ]] && cp -RL ${config
 # copy any artifact changes mounted to artifact_volume
 test -d ${artifact_volume} && [[ "$(ls -A ${artifact_volume})" ]] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
+server_pid=""
+
+stop_handler() {
+  echo "Stopping WSO2 gracefully..." >&2
+  sh "${WSO2_SERVER_HOME}/bin/api-manager.sh" stop
+  wait "${server_pid}"
+}
+
+trap 'stop_handler' SIGTERM SIGINT
+
 # start WSO2 Carbon server
 echo "Start WSO2 Carbon server" >&2
-sh ${WSO2_SERVER_HOME}/bin/api-manager.sh "$@"
+sh ${WSO2_SERVER_HOME}/bin/api-manager.sh "$@" &
+server_pid=$!
+wait "${server_pid}"

--- a/dockerfiles/ubuntu/apim/docker-entrypoint.sh
+++ b/dockerfiles/ubuntu/apim/docker-entrypoint.sh
@@ -60,7 +60,7 @@ stop_handler() {
   echo "Stopping WSO2 gracefully..." >&2
   sh "${WSO2_SERVER_HOME}/bin/api-manager.sh" stop || true
   if [[ -n "${server_pid}" ]]; then
-    wait "${server_pid}" || sleep 60
+    kill -0 "${server_pid}" 2>/dev/null && wait "${server_pid}"
   fi
 }
 
@@ -70,4 +70,4 @@ trap 'stop_handler' SIGTERM SIGINT
 echo "Start WSO2 Carbon server" >&2
 sh "${WSO2_SERVER_HOME}/bin/api-manager.sh" "$@" &
 server_pid=$!
-wait "${server_pid}" || sleep 60
+kill -0 "${server_pid}" 2>/dev/null && wait "${server_pid}"

--- a/dockerfiles/ubuntu/apim/docker-entrypoint.sh
+++ b/dockerfiles/ubuntu/apim/docker-entrypoint.sh
@@ -57,11 +57,13 @@ test -d ${artifact_volume} && [[ "$(ls -A ${artifact_volume})" ]] && cp -RL ${ar
 server_pid=""
 
 stop_handler() {
+  trap - SIGTERM SIGINT
   echo "Stopping WSO2 gracefully..." >&2
   sh "${WSO2_SERVER_HOME}/bin/api-manager.sh" stop || true
   if [[ -n "${server_pid}" ]]; then
     kill -0 "${server_pid}" 2>/dev/null && wait "${server_pid}"
   fi
+  exit 0
 }
 
 trap 'stop_handler' SIGTERM SIGINT

--- a/dockerfiles/ubuntu/apim/docker-entrypoint.sh
+++ b/dockerfiles/ubuntu/apim/docker-entrypoint.sh
@@ -58,14 +58,16 @@ server_pid=""
 
 stop_handler() {
   echo "Stopping WSO2 gracefully..." >&2
-  sh "${WSO2_SERVER_HOME}/bin/api-manager.sh" stop
-  wait "${server_pid}"
+  sh "${WSO2_SERVER_HOME}/bin/api-manager.sh" stop || true
+  if [[ -n "${server_pid}" ]]; then
+    wait "${server_pid}"
+  fi
 }
 
 trap 'stop_handler' SIGTERM SIGINT
 
 # start WSO2 Carbon server
 echo "Start WSO2 Carbon server" >&2
-sh ${WSO2_SERVER_HOME}/bin/api-manager.sh "$@" &
+sh "${WSO2_SERVER_HOME}/bin/api-manager.sh" "$@" &
 server_pid=$!
 wait "${server_pid}"


### PR DESCRIPTION
## Purpose 

to improve the shutdown handling of all WSO2 API Manager container images (for Alpine, Rocky, and Ubuntu) by adding proper signal trapping and graceful shutdown logic to each `docker-entrypoint.sh` script. The main goal is to ensure that when the container receives a termination signal (SIGTERM or SIGINT), the WSO2 server stops cleanly, preventing potential data corruption or incomplete shutdowns.

The most important changes are:

**Graceful shutdown and signal handling:**

* Added a `stop_handler` function in each `docker-entrypoint.sh` script to trap SIGTERM and SIGINT signals, call the appropriate WSO2 stop script, and wait for the server process to exit before terminating the container. This ensures a clean shutdown sequence. 
* 
**Server process management:**

* Modified the server startup commands to run the WSO2 server in the background, capture its PID, and wait on that process. This allows the entrypoint script to remain responsive to signals and manage the server lifecycle correctly. [


Applied the above changes consistently across all supported distributions and profiles: Alpine, Rocky, and Ubuntu for `apim`, `apim-acp`, `apim-tm`, and `apim-universal-gw` images.

- Resolves : https://github.com/wso2/api-manager/issues/4842