### PR TITLE
Remove python-is-python3 from Ubuntu Dockerfiles

### DIFF
--- a/dockerfiles/ubuntu/apim-acp/Dockerfile
+++ b/dockerfiles/ubuntu/apim-acp/Dockerfile
@@ -23,7 +23,7 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 # install dependencies
 RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata curl ca-certificates fontconfig locales python-is-python3 libxml2-utils netcat-traditional unzip wget \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata curl ca-certificates fontconfig locales libxml2-utils netcat-traditional unzip wget \
     && echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
     && locale-gen en_US.UTF-8 \
     && rm -rf /var/lib/apt/lists/*

--- a/dockerfiles/ubuntu/apim-tm/Dockerfile
+++ b/dockerfiles/ubuntu/apim-tm/Dockerfile
@@ -23,7 +23,7 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 # install dependencies
 RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata curl ca-certificates fontconfig locales python-is-python3 libxml2-utils netcat-traditional unzip wget \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata curl ca-certificates fontconfig locales libxml2-utils netcat-traditional unzip wget \
     && echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
     && locale-gen en_US.UTF-8 \
     && rm -rf /var/lib/apt/lists/*

--- a/dockerfiles/ubuntu/apim-universal-gw/Dockerfile
+++ b/dockerfiles/ubuntu/apim-universal-gw/Dockerfile
@@ -23,7 +23,7 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 # install dependencies
 RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata curl ca-certificates fontconfig locales python-is-python3 libxml2-utils netcat-traditional unzip wget \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata curl ca-certificates fontconfig locales libxml2-utils netcat-traditional unzip wget \
     && echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
     && locale-gen en_US.UTF-8 \
     && rm -rf /var/lib/apt/lists/*

--- a/dockerfiles/ubuntu/apim/Dockerfile
+++ b/dockerfiles/ubuntu/apim/Dockerfile
@@ -23,7 +23,7 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 # install dependencies
 RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata curl ca-certificates fontconfig locales python-is-python3 libxml2-utils netcat-traditional unzip wget \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata curl ca-certificates fontconfig locales libxml2-utils netcat-traditional unzip wget \
     && echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
     && locale-gen en_US.UTF-8 \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Purpose

Removes the `python-is-python3` package from the Ubuntu Dockerfiles. This package is not required by the WSO2 API Manager runtime and only adds an unnecessary dependency to the image.

## Changes

Removed `python-is-python3` from the `apt-get install` dependency list in:

- `dockerfiles/ubuntu/apim/Dockerfile`
- `dockerfiles/ubuntu/apim-acp/Dockerfile`
- `dockerfiles/ubuntu/apim-tm/Dockerfile`
- `dockerfiles/ubuntu/apim-universal-gw/Dockerfile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)